### PR TITLE
Remove errant newline causing TOC to disappear

### DIFF
--- a/docs/MMTC_Users_Guide.adoc
+++ b/docs/MMTC_Users_Guide.adoc
@@ -4,7 +4,6 @@
 :revnumber: 1.6.0-SNAPSHOT
 :revremark: Rev G
 :imagesdir: ./images/
-
 :toc: macro
 :toc-title:
 :toclevels: 2


### PR DESCRIPTION
Remove blank line 7 to correct table of contents failing to appear in user's guide