### PR TITLE
Add handling for ASSIGN_KEY clkchgratemode in TimeHistFile creation

### DIFF
--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/TimeCorrelationApp.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/TimeCorrelationApp.java
@@ -316,6 +316,7 @@ public class TimeCorrelationApp {
                 timeHistoryFileRecord.setValue(TimeHistoryFile.CLK_CHANGE_RATE_MODE, "P");
                 break;
             case ASSIGN:
+            case ASSIGN_KEY:
                 timeHistoryFileRecord.setValue(TimeHistoryFile.CLK_CHANGE_RATE_MODE, "A");
                 break;
             case NO_DRIFT:


### PR DESCRIPTION
Add fallthrough case for the new ClkChgRateMode `ASSIGN_KEY` added in 1.5.0 to the creation of the TimeHistoryFile. Runs with the `--clkchgratemode-assign {prefix}` CLI option should now have "A" noted as the clkchgratemode in the time history file.

Tested manually by running MMTC 1.6.0-SNAPSHOT with args `2017-342T00:00:00 2017-342T23:59:59 -F --clkchgrate-assign preset1` with preset1=1.0 in the config file. Resulting TimeHistoryFile entry:
![image](https://github.com/user-attachments/assets/6dfbb8cb-d540-4bb7-977b-bd5ee43f99c8)
