### PR TITLE
[DRAFT] 8 add a cli option for a dry run mode

### DIFF
--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/TimeCorrelationApp.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/TimeCorrelationApp.java
@@ -1019,14 +1019,14 @@ public class TimeCorrelationApp {
     }
 
     private void logProductContents(String productType, String[] entries) {
-        logger.info("************ BEGIN DRY RUN {} RECORD ************", productType);
+        logger.info("<<<<<<<<<<<< BEGIN DRY RUN {} RECORD <<<<<<<<<<<<", productType);
         if(productType.equals("SCLK KERNEL")) {
             logger.info("[Omitting {} unmodified triplets and recording last two entries of new file]", newSclkKernel.getNumTriplets());
         }
         for (String entry : entries) {
             logger.info(entry);
         }
-        logger.info("************ END DRY RUN {} RECORD ************", productType);
+        logger.info(">>>>>>>>>>>> END DRY RUN {} RECORD >>>>>>>>>>>>", productType);
     }
 
     /**
@@ -1263,6 +1263,11 @@ public class TimeCorrelationApp {
 
             writeRunHistoryFileAfterRun();
             logger.info(String.format("Run at %s recorded to %s", appRunTime, config.getRunHistoryFileUri().toString()));
+        } else {
+            // Record the new table entries in the log
+            logProductContents("RAW TLM TABLE", new String[] {rawTlmTable.getHeaders().toString(), rawTlmTableRecord.getValues().toString()});
+            logProductContents("RAW TLM TABLE", new String[] {summaryTable.getHeaders().toString(), summaryTableRecord.getValues().toString()});
+            logProductContents("RAW TLM TABLE", new String[] {timeHistoryFile.getHeaders().toString(), timeHistoryFileRecord.getValues().toString()});
         }
 
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/CommandLineConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/CommandLineConfig.java
@@ -95,6 +95,14 @@ public class CommandLineConfig implements IConfiguration {
                 "Run in test mode, which allows the user to override one-way-light-time."
         );
 
+        opts.addOption(
+                "D",
+                "dry-run",
+                false,
+                "Executes a dry run of MMTC with outputs calculated as otherwise configured " +
+                        "but only records them in the log without writing/modifying product files."
+        );
+
         opts.addOption("v", "version", false, "Print the MMTC version number.");
 
         opts.addOption("h", "help", false, "Print this message.");
@@ -186,6 +194,10 @@ public class CommandLineConfig implements IConfiguration {
 
     double getTestModeOwlt() {
         return Double.parseDouble(cmdLine.getOptionValue('T'));
+    }
+
+    boolean isDryRun() {
+        return cmdLine.hasOption("D") || cmdLine.hasOption("dry-run");
     }
 
     boolean isGenerateCmdFile() {

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/TimeCorrelationAppConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/TimeCorrelationAppConfig.java
@@ -288,12 +288,21 @@ public class TimeCorrelationAppConfig {
     public double getTestModeOwlt() { return cmdLineConfig.getTestModeOwlt(); }
 
     /**
+     * Indicates if this is a dry run
+     *
+     * @return true if -D or --dry-run CLI options are invoked
+     */
+    public boolean isDryRun() {
+        return cmdLineConfig.isDryRun();
+    }
+
+    /**
      * As is the case with the other filters, the contact filter can be enabled or
      * disabled from the parameter file, which is the preferred way to do it.
      * However, it can also be disabled from the command line with the
      * --disable-contact-filter or -F command line option. The command line option
      * overrides the configuration filter.contact.enabled paramter setting.
-     * 
+     *
      * @return true if the contact filter is DISABLED, false if enabled
      * @throws MmtcException if contact filter is not disabled from the
      *                                  command line and is also missing from
@@ -335,7 +344,7 @@ public class TimeCorrelationAppConfig {
      * command line options. If no relevant command line options are passed in, then
      * this is determined by the configuration file. If no relevant option is found
      * in the configuration file, then this falls back to a default method.
-     * 
+     *
      * @throws MmtcException if the configuration file contains an
      *                                  invalid value for the clock change rate mode
      *                                  option.
@@ -449,7 +458,7 @@ public class TimeCorrelationAppConfig {
      * Get the maximum virtual channel frame counter value a frame can be assigned before the next frame's virtual
      * channel frame index is assigned zero. Depending on mission, this can range anywhere from a few hundred to 
      * a few million, so MMTC needs to know when to expect a VCFC rollover.
-     * 
+     *
      * @return the maximum virtual channel frame counter value before the counter rolls over to 0
      */
     public int getVcfcMaxValue() {
@@ -700,7 +709,7 @@ public class TimeCorrelationAppConfig {
     /**
      * Indicates whether the VCID filter is enabled. Note that this method does not throw if the VCID filter is missing
      * from the configuration file altogether.
-     * 
+     *
      * @return true if the VCID filter is enabled in the configuration file, false
      *         otherwise (including if an exception occurs while reading the
      *         configuration)
@@ -716,7 +725,7 @@ public class TimeCorrelationAppConfig {
 
     /**
      * Gets the valid VCID groups.
-     * 
+     *
      * @return the groups of valid VCIDs
      * @throws MmtcException if the groups are not specified in the
      *                                  configuration file, the value is empty, or the value contains
@@ -1088,7 +1097,7 @@ public class TimeCorrelationAppConfig {
      * correlated times will be offset by a "Bit Rate Error" time delay. This delay
      * can be computed from the downlink rate and the bit offset between the parts
      * of the frame that the spacecraft and the ground station use.
-     * 
+     *
      * This method gets the configuration value that represents that bit offset.
      *
      * @return the bit offset between the parts of the frame that the spacecraft and

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/SclkKernel.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/SclkKernel.java
@@ -371,4 +371,8 @@ public class SclkKernel extends TextProduct {
             throw new TextProductException("Invalid input SCLK Kernel. No time correlation records found.");
         }
     }
+
+    public int getNumTriplets() {
+        return this.endDataNum - firstDataRecNum(sourceProduct);
+    }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/TextProduct.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/TextProduct.java
@@ -164,6 +164,23 @@ abstract class TextProduct {
         return sourceProduct.get(lastDataRecNum(sourceProduct)).trim();
     }
 
+    /**
+     * Gets the last x records in the original source product
+     *
+     * @param numRecords the number of records to return
+     * @return a String array of records in their original order, else an empty array if numRecords is invalid
+     */
+    public String[] getLastXRecords(int numRecords) {
+        if(numRecords < 1) { return new String[0]; }
+        int lastRecordIndex = lastDataRecNum(sourceProduct);
+
+        String[] records = new String[numRecords];
+        for(int i=lastRecordIndex-(numRecords-1), j=0;i < lastRecordIndex+1; i++, j++) {
+            records[j] = sourceProduct.get(i);
+        }
+        return records;
+    }
+
 
     /**
      * Creates a new product file from an existing source file and writes it to the directory

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/UplinkCmdFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/UplinkCmdFile.java
@@ -22,6 +22,7 @@ public class UplinkCmdFile {
 
     private String         filespec;
     private BufferedWriter writer;
+    private UplinkCommand commandString;
 
     public UplinkCmdFile(String filespec) {
         this.filespec = filespec;
@@ -30,13 +31,20 @@ public class UplinkCmdFile {
     /**
      * Writes the CSV format uplink command record to the Uplink Command File.
      *
-     * @param commandString the uplink command parameters
      * @throws IOException if the file cannot be written
      */
-    public void write(UplinkCommand commandString) throws IOException  {
+    public void write() throws IOException  {
         writer = new BufferedWriter(new FileWriter(filespec));
         writer.write(commandString.toString());
         writer.close();
         logger.info(TimeCorrelationApp.USER_NOTICE, "Wrote new uplink command file at: " + Paths.get(filespec));
+    }
+
+    public void setCommandString(UplinkCommand commandString) {
+        this.commandString = commandString;
+    }
+
+    public UplinkCommand getCommandString() {
+        return this.commandString;
     }
 }


### PR DESCRIPTION
Draft until I can write some e2e tests in the private repo and figure out associated workflows, but code here is more or less complete with a few commented caveats below and can be reviewed whenever. 

Summary of changes to TimeCorrelationApp:
Expanded scope of `TableRecord rawTlmTableRecord` and `SclkScetfile scetfile` to instance variables (now matches that of all other output products and are treated similarly). Adjusted table product write methods to instead just create/update the products (with names changed accordingly); they're then written later if logic determines it isn't a dry run. 
For text products, scet files currently REQUIRE the existence of a sclk kernel, so choosing not to write the latter isn't an option--instead, sclk kernel and scet file are simply deleted after their new entries have been logged in dry runs. I don't feel like this is very elegant but the alternative would require significant fundamental changes to how scet files and kernels are created.

Added some helper methods to SclkKernel, TextProduct, and added necessary changes to support new command line option.