### PR TITLE
24: Modify SCLKSCET creation date formatting method to left-pad DOY

### DIFF
--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/TextProduct.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/TextProduct.java
@@ -98,7 +98,7 @@ abstract class TextProduct {
      * @return the date/time string
      */
     public String getProductDateTimeIsoUtc() {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-D'T'HH:mm:ss.SSS");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-DDD'T'HH:mm:ss.SSS");
         OffsetDateTime utc          = productCreationTimeUtc;
         String newDateTime          = utc.format(formatter);
 


### PR DESCRIPTION
This is the only place this method is used so there's no danger of unwanted changes to date formatting anywhere else. Tested by modifying system time to Jan 1 2025 with `timedatectl`, resulting sclkscet file header below.

<details><summary>new-horizons_1022.sclkscet</summary>
<p>

CCSD3ZS00001$$sclk$$NJPL3KS0L015$$scet$$
MISSION_NAME=New Horizons;
SPACECRAFT_NAME=New Horizons;
DATA_SET_ID=SCLK_SCET;
FILE_NAME=new-horizons_1022.sclkscet;
PRODUCT_CREATION_TIME=2025-001T00:05:51.560;
PRODUCT_VERSION_ID=1022;
PRODUCER_ID=MMTC;
APPLICABLE_START_TIME=2006-019T18:08:00.000000;
APPLICABLE_STOP_TIME=2017-343T15:50:19.767407;
MISSION_ID=98;
SPACECRAFT_ID=98;
CCSD3RE00000$$scet$$NJPL3IS00613$$data$$
*____SCLK0_______  ____SCET0____________ _DUT__ _SCLKRATE___
 000000000000.000  2006-019T18:08:00.000000 65.184 1.0000000000

</p>
</details> 