### PR TITLE
Update MMTC's build system and dependencies for 1.6.0 cycle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,9 +5,9 @@ import org.asciidoctor.gradle.jvm.pdf.AsciidoctorPdfTask
 
 plugins {
     distribution
-    id("com.netflix.nebula.ospackage") version "11.4.0"
-    id("org.asciidoctor.jvm.convert") version "4.0.2"
-    id("org.asciidoctor.jvm.pdf") version "4.0.2"
+    id("com.netflix.nebula.ospackage") version "11.11.2"
+    id("org.asciidoctor.jvm.convert") version "4.0.4"
+    id("org.asciidoctor.jvm.pdf") version "4.0.4"
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/mmtc-core/build.gradle.kts
+++ b/mmtc-core/build.gradle.kts
@@ -17,8 +17,8 @@ dependencies {
         "configuration" to "precompiledClasses"
     )))
 
-    implementation("commons-beanutils:commons-beanutils:1.9.3")
-    implementation("org.apache.commons:commons-configuration2:2.4")
+    implementation("commons-beanutils:commons-beanutils:1.11.0")
+    implementation("org.apache.commons:commons-configuration2:2.12.0")
     implementation(libs.commons.cli)
     implementation(libs.commons.csv)
     implementation(libs.commons.lang3)
@@ -29,6 +29,7 @@ dependencies {
     testImplementation(testlibs.junit.jupiter.api)
     testImplementation(testlibs.junit.jupiter.params)
     testImplementation(testlibs.junit.jupiter.engine)
+    testRuntimeOnly(testlibs.junit.platform.launcher)
     testImplementation(testlibs.mockito.inline)
 }
 

--- a/mmtc-plugin-ampcs/build.gradle.kts
+++ b/mmtc-plugin-ampcs/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     testImplementation(testlibs.junit.jupiter.api)
     testImplementation(testlibs.junit.jupiter.params)
     testImplementation(testlibs.junit.jupiter.engine)
+    testRuntimeOnly(testlibs.junit.platform.launcher)
     testImplementation(testlibs.mockito.inline)
 }
 

--- a/mmtc-tlm-source-plugin-sdk/build.gradle.kts
+++ b/mmtc-tlm-source-plugin-sdk/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     testImplementation(testlibs.junit.jupiter.api)
     testImplementation(testlibs.junit.jupiter.params)
     testImplementation(testlibs.junit.jupiter.engine)
+    testRuntimeOnly(testlibs.junit.platform.launcher)
     testImplementation(testlibs.mockito.inline)
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,19 +13,20 @@ include(":jnispice")
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
-            library("commons-csv", "org.apache.commons:commons-csv:1.6")
-            library("commons-lang3", "org.apache.commons:commons-lang3:3.9")
-            library("commons-cli", "commons-cli:commons-cli:1.4")
+            library("commons-csv", "org.apache.commons:commons-csv:1.14.0")
+            library("commons-lang3", "org.apache.commons:commons-lang3:3.18.0")
+            library("commons-cli", "commons-cli:commons-cli:1.9.0")
 
-            library("log4j-api", "org.apache.logging.log4j:log4j-api:2.19.0")
-            library("log4j-core", "org.apache.logging.log4j:log4j-core:2.19.0")
-            library("log4j-jcl", "org.apache.logging.log4j:log4j-jcl:2.19.0")
+            library("log4j-api", "org.apache.logging.log4j:log4j-api:2.25.1")
+            library("log4j-core", "org.apache.logging.log4j:log4j-core:2.25.1")
+            library("log4j-jcl", "org.apache.logging.log4j:log4j-jcl:2.25.1")
         }
 
         create("testlibs") {
-            library("junit-jupiter-api", "org.junit.jupiter:junit-jupiter-api:5.6.0")
-            library("junit-jupiter-params", "org.junit.jupiter:junit-jupiter-params:5.6.0")
-            library("junit-jupiter-engine", "org.junit.jupiter:junit-jupiter-engine:5.6.0")
+            library("junit-jupiter-api", "org.junit.jupiter:junit-jupiter-api:5.13.4")
+            library("junit-jupiter-params", "org.junit.jupiter:junit-jupiter-params:5.13.4")
+            library("junit-jupiter-engine", "org.junit.jupiter:junit-jupiter-engine:5.13.4")
+            library("junit-platform-launcher", "org.junit.platform:junit-platform-launcher:1.13.4")
             library("mockito-inline", "org.mockito:mockito-inline:4.11.0")
         }
     }


### PR DESCRIPTION
- Updates Gradle from 8.2.1 to 8.14.3 (and versioned Gradle plugins)
- Updates Java compile/runtime & test dependencies to latest versions known to be compatible with Java 8