### PR TITLE
[MMTC-11] Automated sandbox creation

### DIFF
--- a/docs/MMTC_Users_Guide.adoc
+++ b/docs/MMTC_Users_Guide.adoc
@@ -234,14 +234,14 @@ by modifying the key
 
 [source, xml]
 ----
-<entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///opt/local/mmtc/RawTelemetryTable_NH_reformatted.csv</entry>
+<entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/opt/local/mmtc/RawTelemetryTable_NH_reformatted.csv</entry>
 ----
 
 to:
 
 [source, xml]
 ----
-<entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///[MMTC Demo directory\]/RawTelemetryTable_NH_reformatted.csv</entry>
+<entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/[MMTC Demo directory\]/RawTelemetryTable_NH_reformatted.csv</entry>
 ----
 
 
@@ -745,7 +745,7 @@ Plugins that aren't included with MMTC and which are obtained from other sources
 
 MMTC creates and writes to a cumulative output file called the Raw Telemetry Table. The Raw Telemetry Table stores a record of the raw time correlation data that were used to perform all previous time correlations. MMTC appends to it each time it runs. This file can also serve as an input, thus allowing time correlation computations to be rerun. This is useful in I&T environments where TK packets are not available or when there is a need to reprocess time correlations. This need can arise due to errors having occurred in the previous runs or when an improved spacecraft ephemeris is available that will provide for more accuracy.
 
-When the *telemetry.source.name* configuration parameter is set to `rawTlmTable`, MMTC will read its input from the Raw Telemetry Table indicated in the *telemetry.source.plugin.rawTlmTable.tableFile.uri* configuration parameter. The fields in the Time History File that would normally contain ancillary data from telemetry will be empty.
+When the *telemetry.source.name* configuration parameter is set to `rawTlmTable`, MMTC will read its input from the Raw Telemetry Table indicated in the *telemetry.source.plugin.rawTlmTable.tableFile.path* configuration parameter. The fields in the Time History File that would normally contain ancillary data from telemetry will be empty.
 
 === AMPCS Telemetry Sources
 
@@ -812,7 +812,7 @@ A set of Time Correlation (TK) packets received from spacecraft telemetry is the
 
 As in the case of the Europa Clipper mission, the TK packet may also contain a validity flag, the frame encoding method, and the downlink data rate.
 
-The structure of the TK packet is defined in the TK Packet Description file. This is an XML file that conforms to the *tk_packet.xsd* schema (see section 8.3). This packet defines the bit offsets from the beginning of the packet of each field, their lengths in bits, and their expected type. Type for all fields is expected to be UNSIGNED_INT except for DownlinkDataRate which can be UNSIGNED_INT, SINGLE_FLOAT, or DOUBLE_FLOAT. This file must be customized for each mission. The name and location of this file is given in *telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri* within the configuration parameters.
+The structure of the TK packet is defined in the TK Packet Description file. This is an XML file that conforms to the *tk_packet.xsd* schema (see section 8.3). This packet defines the bit offsets from the beginning of the packet of each field, their lengths in bits, and their expected type. Type for all fields is expected to be UNSIGNED_INT except for DownlinkDataRate which can be UNSIGNED_INT, SINGLE_FLOAT, or DOUBLE_FLOAT. This file must be customized for each mission. The name and location of this file is given in *telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path* within the configuration parameters.
 
 ==== Channelized Time Correlation Parameters
 
@@ -1087,9 +1087,9 @@ If the ConsecutiveFrameFilter is enabled, this must be set to a specific positiv
 |telemetry.source.name
 |REQUIRED
 |STR
-|Indicates which telemetry source to use. A value of "rawTlmTable" causes MMTC to use the Raw Telemetry Table specified by telemetry.source.plugin.
-rawTlmTable.tableFile.uri; this would generally only be useful in test venues or if a previous run needs to be reprocessed. Otherwise, valid values depend on the telemetry source plugin specified by telemetry.source.pluginDirectory and telemetry.
-source.pluginJarPrefix; consult the plugin provider for instructions.
+|Indicates which telemetry source to use. A value of "rawTlmTable" causes MMTC to use the Raw Telemetry Table source, which reads telemetry from a file specified by telemetry.source.plugin.rawTlmTable.tableFile.path.
+This is generally useful in test venues or development. Otherwise, valid values depend on the telemetry source plugin specified by telemetry.source.pluginDirectory and telemetry.
+source.pluginJarPrefix; consult the plugin provider for guidance.
 When using the AMPCS plugin that ships with MMTC, valid values for telemetry.source.name are “AmpcsTlmArchive” and “AmpcsTlmWithFrames”:
 
 • AmpcsTlmArchive: Query all information from TK packets from the AMPCS TLM archive. Use if consecutive TK packets are available to build a sample set.
@@ -1097,10 +1097,10 @@ When using the AMPCS plugin that ships with MMTC, valid values for telemetry.sou
 • AmpcsTlmWithFrames: Query supplemental sample information from a TK packet. Query the target sample information from the frame referenced from within the TK packet. Use if consecutive TK packets are not available. NOTE: In this mode, the TK packets must contain the downlink data rate in bps.
 
 
-|telemetry.source.plugin.rawTlmTable.tableFile.uri
+|telemetry.source.plugin.rawTlmTable.tableFile.path
 |CONDITIONAL
 |STR
-|The fully qualified path to the input Raw Telemetry Table file. This parameter is ignored if telemetry.
+|The path to the input Raw Telemetry Table file. This parameter is ignored if telemetry.
 source.name is not set to rawTlmTable.
 
 |telemetry.source.pluginDirectory
@@ -1306,20 +1306,25 @@ Always set this value to false if using the AMPCS telemetry source plugin’s Am
 
 4+^|*The following parameters relate to the location and contents of MMTC output products*
 
-|table.rawTelemetryTable.uri
+|table.runHistoryFile.path
 |REQUIRED
 |STR
-|The desired URI of the output Raw Telemetry Table file.
+|The desired path of the Run History File.  This file and other output tables are commonly co-located.
+
+|table.rawTelemetryTable.path
+|REQUIRED
+|STR
+|The desired path of the output Raw Telemetry Table file. This file and other output tables are commonly co-located.
 
 |table.rawTelemetryTable.dateTimePattern
 |REQUIRED
 |STR
 |The pattern that is used to parse ERTs from query metadata and to write ERT to the RawTlmTable in calendar string date/time form (e.g., ISO DOY format: “yyyy-DDD’T’HH:mm:ss.SSSSSS”).
 
-|table.timeHistoryFile.uri
+|table.timeHistoryFile.path
 |REQUIRED
 |STR
-|The desired URI of the output Time History File.
+|The desired path of the output Time History File. This file and other output tables are commonly co-located.
 
 |table.timeHistoryFile.excludeColumns
 |OPTIONAL
@@ -1435,7 +1440,7 @@ The parameters in the table below are only applicable to missions using AMPCS wh
 |INT
 |The size in bytes of the TK packet, excluding the primary packet header minus 1. In other words, the size of the data portion of the packet, which includes the secondary header, minus 1.
 
-|telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri
+|telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path
 |REQUIRED
 |STR
 |The path to the XML file that describes the TK packet.
@@ -1667,7 +1672,7 @@ At a minimum, the TK packet must contain a coarse SCLK value and a fine SCLK val
 
 The user is reminded that the SCLK Coarse and SCLK Fine values are associated with the target frame, NOT the frame containing the TK packet. The target frame is usually, but not always, the frame that immediately precedes the supplemental frame (i.e., the one containing the TK packet) in the telemetry sequence. In other words, the VCFC of the target frame is a set number of counts (usually just 1) less than that of the supplemental frame. The number of frames that the supplemental frame follows the target frame is specified in the *telemetry.supplementalSampleOffset* configuration parameter.
 
-The structure of TK packets is mission-specific. Each mission must describe its TK packets using a TK Packet Description XML file that implements the *tk_packet.xsd* schema provided with the MMTC distribution. The full path to the TK Packet Description file is indicated in the *telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri* configuration parameter. Not all fields are applicable for all missions; however all missions must provide at minimum the SCLK Coarse and SCLK Fine fields in order to process.
+The structure of TK packets is mission-specific. Each mission must describe its TK packets using a TK Packet Description XML file that implements the *tk_packet.xsd* schema provided with the MMTC distribution. The full path to the TK Packet Description file is indicated in the *telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path* configuration parameter. Not all fields are applicable for all missions; however all missions must provide at minimum the SCLK Coarse and SCLK Fine fields in order to process. See Appendix H. for an example of a TK Packet Description file.
 
 The primary purpose of the definition file is to specify the locations and bit lengths of these fields within the packet so that the MMTC can decom them. Each field given in the definition file is identified by a name, the offset from the beginning of the packet (normally the first bit of the primary packet header), and the length of the field in bits.
 

--- a/mmtc-core/bin/mmtc
+++ b/mmtc-core/bin/mmtc
@@ -27,6 +27,8 @@ then
     echo "TK_CONFIG_PATH environment variable not set; defaulting to ${TK_CONFIG_PATH}"
 fi
 
+echo
+
 exec ${JAVA_HOME}/bin/java \
     -jar \
     -Djava.library.path=${MMTC_HOME}/lib/naif/JNISpice/lib \

--- a/mmtc-core/build.gradle.kts
+++ b/mmtc-core/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(libs.log4j.api)
     implementation(libs.log4j.core)
     implementation(libs.log4j.jcl)
+    implementation(libs.commons.io)
 
     testImplementation(testlibs.junit.jupiter.api)
     testImplementation(testlibs.junit.jupiter.params)
@@ -71,7 +72,7 @@ val uberJar = tasks.register<Jar>("uberJar") {
 
     manifest {
         attributes(
-                "Main-Class" to "edu.jhuapl.sd.sig.mmtc.app.TimeCorrelationApp",
+                "Main-Class" to "edu.jhuapl.sd.sig.mmtc.app.MmtcCli",
                 "Build-Date" to Instant.now().toString(),
                 "Implementation-Version" to project.version,
                 "Implementation-Title" to project.name

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/MmtcCli.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/MmtcCli.java
@@ -1,0 +1,122 @@
+package edu.jhuapl.sd.sig.mmtc.app;
+
+import edu.jhuapl.sd.sig.mmtc.rollback.TimeCorrelationRollback;
+import edu.jhuapl.sd.sig.mmtc.sandbox.MmtcSandboxCreator;
+import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
+import org.apache.commons.cli.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class MmtcCli {
+    public static final Marker USER_NOTICE = MarkerManager.getMarker("USER_NOTICE");
+
+    public static final String MMTC_TITLE = "Multi-Mission Time Correlation (MMTC)";
+    public static final BuildInfo BUILD_INFO = new BuildInfo();
+
+    private static final Logger logger = LogManager.getLogger();
+
+    public enum ApplicationCommand {
+        CORRELATION,
+        ROLLBACK,
+        CREATE_SANDBOX
+    }
+
+    private static class ApplicationInvocation {
+        private final ApplicationCommand command;
+        private final String[] args;
+
+        public ApplicationInvocation(ApplicationCommand command, String... args) {
+            this.command = command;
+            this.args = args;
+        }
+    }
+
+    private static ApplicationInvocation determineApplicationCommand(String... cliArgs) throws MmtcException {
+        if (Arrays.asList("-v", "--version").contains(cliArgs[0])) {
+            System.out.println(MmtcCli.BUILD_INFO);
+            System.exit(0);
+        }
+
+        if (Arrays.asList("-h", "--help").contains(cliArgs[0])) {
+            final String helpMessage =
+                    "usage: mmtc [correlation|rollback|create-sandbox] [options] <additional arguments>\n" +
+                    " -h,--help      Print this message.\n" +
+                    " -v,--version   Print the MMTC version number.\n" +
+                    "\n" +
+                    "MMTC can be invoked with one of three commands:\n" +
+                    "- correlation: run a new correlation (this is the default command if none\n" +
+                    "is specified)\n" +
+                    "- rollback: roll back (undo) one or many correlations\n" +
+                    "- create-sandbox: create a copy of this MMTC installation to run locally,\n" +
+                    "without affecting this installation\n" +
+                    "\n" +
+                    "For more information on any of these commands, run: mmtc <command> --help";
+            System.out.println(helpMessage);
+            System.exit(0);
+        }
+
+        if (cliArgs[0].equalsIgnoreCase("rollback")) {
+            return new ApplicationInvocation(ApplicationCommand.ROLLBACK, removeFirstElement(cliArgs));
+        } else if (cliArgs[0].equalsIgnoreCase("create-sandbox")) {
+            return new ApplicationInvocation(ApplicationCommand.CREATE_SANDBOX, removeFirstElement(cliArgs));
+        } else if (cliArgs[0].equalsIgnoreCase("correlation")) {
+            return new ApplicationInvocation(ApplicationCommand.CORRELATION, removeFirstElement(cliArgs));
+        } else {
+            // to maintain backwards compatibility on MMTC's CLI
+            return new ApplicationInvocation(ApplicationCommand.CORRELATION, cliArgs);
+        }
+    }
+
+    private static String[] removeFirstElement(String... arr) {
+        List<String> arrList = new ArrayList<>(Arrays.asList(arr));
+        arrList.remove(0);
+        return arrList.toArray(new String[arr.length - 1]);
+    }
+
+    /**
+     * Entry point of the application.
+     *
+     * @param args command line arguments
+     */
+    public static void main(String[] args) throws Exception {
+        logger.info(String.format("************ %s version %s ************", MMTC_TITLE, BUILD_INFO.version));
+        logger.info(String.format("Commit %s built at %s", BUILD_INFO.commit, BUILD_INFO.buildDate));
+
+        final ApplicationInvocation appInvoc = determineApplicationCommand(args);
+
+        switch (appInvoc.command) {
+            case CORRELATION: {
+                try {
+                    new TimeCorrelationApp(appInvoc.args).run();
+                } catch (Exception ex) {
+                    logger.fatal("MMTC correlation run failed.", ex);
+                    System.exit(1);
+                }
+                break;
+            }
+            case ROLLBACK: {
+                try {
+                    new TimeCorrelationRollback(appInvoc.args).rollback();
+                } catch (Exception e) {
+                    logger.fatal("Rollback failed.", e);
+                    System.exit(1);
+                }
+                break;
+            }
+            case CREATE_SANDBOX: {
+                try {
+                    new MmtcSandboxCreator(appInvoc.args).create();
+                } catch (Exception e) {
+                    logger.fatal("Sandbox creation failed.", e);
+                    System.exit(1);
+                }
+            }
+        }
+    }
+}

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/AbstractConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/AbstractConfig.java
@@ -1,17 +1,19 @@
 package edu.jhuapl.sd.sig.mmtc.cfg;
 
+import java.nio.file.Path;
+
 /**
  * Defines an abstract class for configuration files.
  */
 abstract class AbstractConfig implements IConfiguration {
-    String path;
+    Path path;
 
     /**
      * Create the configuration object with the specified filename.
      *
      * @param path the name of the configuration file
      */
-    AbstractConfig(final String path) {
+    AbstractConfig(final Path path) {
         this.path = path;
     }
 
@@ -27,13 +29,13 @@ abstract class AbstractConfig implements IConfiguration {
      *
      * @param filepath the full path to the configuration file
      */
-    void setPath(String filepath) {
+    void setPath(Path filepath) {
         this.path = filepath;
     }
     /**
      * @return the properties configuration filename
      */
-    String getPath() {
+    Path getPath() {
         return path;
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/CorrelationCommandLineConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/CorrelationCommandLineConfig.java
@@ -1,6 +1,5 @@
 package edu.jhuapl.sd.sig.mmtc.cfg;
 
-import edu.jhuapl.sd.sig.mmtc.app.TimeCorrelationApp;
 import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationAppConfig.ClockChangeRateMode;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
 import org.apache.commons.cli.*;
@@ -8,9 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -22,7 +19,7 @@ import java.util.stream.Collectors;
 /**
  * Defines the command line configuration options for the MMTC application.
  */
-public class CommandLineConfig implements IConfiguration {
+public class CorrelationCommandLineConfig implements IConfiguration {
     private HelpFormatter help = new HelpFormatter();
     private Options opts = new Options();
     private CommandLine cmdLine;
@@ -40,11 +37,11 @@ public class CommandLineConfig implements IConfiguration {
 
     private static final Logger logger = LogManager.getLogger();
 
-    CommandLineConfig(String[] args) {
+    CorrelationCommandLineConfig(String[] args) {
         this(args, Collections.emptyList());
     }
 
-    CommandLineConfig(String[] args, Collection<Option> additionalOptions) {
+    CorrelationCommandLineConfig(String[] args, Collection<Option> additionalOptions) {
         OptionGroup clockChangeRateGroup = new OptionGroup();
 
         clockChangeRateGroup.addOption(Option.builder()
@@ -95,8 +92,6 @@ public class CommandLineConfig implements IConfiguration {
                 "Run in test mode, which allows the user to override one-way-light-time."
         );
 
-        opts.addOption("v", "version", false, "Print the MMTC version number.");
-
         opts.addOption("h", "help", false, "Print this message.");
 
         for (Option additionalOption : additionalOptions) {
@@ -114,6 +109,10 @@ public class CommandLineConfig implements IConfiguration {
         return opts.hasShortOption(option.getOpt()) || opts.hasLongOption(option.getLongOpt());
     }
 
+    public String[] getArgs() {
+        return Arrays.copyOf(this.args, this.args.length);
+    }
+
     public boolean load() {
         try {
             logger.info("Command line arguments: ["
@@ -127,13 +126,7 @@ public class CommandLineConfig implements IConfiguration {
 
             // Print help and exit, regardless of any other arguments
             if (isHelpSet()) {
-                help.printHelp("mmtc [options] <start-time> <stop-time>", opts);
-                System.exit(0);
-            }
-
-            // Else print version and exit, regardless of any other arguments
-            if (isVersionSet()) {
-                System.out.println(TimeCorrelationApp.BUILD_INFO);
+                help.printHelp("mmtc correlation [options] <start-time> <stop-time>", opts);
                 System.exit(0);
             }
 
@@ -143,10 +136,9 @@ public class CommandLineConfig implements IConfiguration {
                 // Convert the input data start/stop times to Java OffsetDateTime.
                 startTime = formDateTime(posArgs[0]);
                 stopTime  = formDateTime(posArgs[1]);
-            }
-            else {
+            } else {
                 System.out.println("Incorrect number of command line arguments. 2 are required, " + posArgs.length + " were provided.");
-                help.printHelp("mmtc [options] <start-time> <stop-time>", opts);
+                help.printHelp("mmtc correlation [options] <start-time> <stop-time>", opts);
                 return false;
             }
         }
@@ -254,10 +246,6 @@ public class CommandLineConfig implements IConfiguration {
 
     private boolean isHelpSet() {
         return cmdLine.hasOption("h") || cmdLine.hasOption("help");
-    }
-
-    private boolean isVersionSet() {
-        return cmdLine.hasOption("v") || cmdLine.hasOption("version");
     }
 
     /**

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/GroundStationMap.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/GroundStationMap.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,7 +45,7 @@ class GroundStationMap extends AbstractConfig {
      * Class constructor
      * @param groundStationMapPath IN:the path to the ground stations map file
      */
-    GroundStationMap(String groundStationMapPath) {
+    GroundStationMap(Path groundStationMapPath) {
         super(groundStationMapPath);
     }
 
@@ -57,10 +58,11 @@ class GroundStationMap extends AbstractConfig {
         try {
             logger.info("Loading Ground Station Map: " + this.path);
 
-            File file = new File(this.path);
-
-            CSVParser parser = CSVParser.parse(file, Charset.forName("utf-8"),
-                    CSVFormat.DEFAULT.withFirstRecordAsHeader().withTrim());
+            CSVParser parser = CSVParser.parse(
+                    this.path,
+                    Charset.forName("utf-8"),
+                    CSVFormat.DEFAULT.withFirstRecordAsHeader().withTrim()
+            );
 
             records = new HashMap<>();
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/MmtcConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/MmtcConfig.java
@@ -1,0 +1,1093 @@
+package edu.jhuapl.sd.sig.mmtc.cfg;
+
+import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.*;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import edu.jhuapl.sd.sig.mmtc.products.SclkKernel;
+import edu.jhuapl.sd.sig.mmtc.tlm.TelemetrySource;
+import edu.jhuapl.sd.sig.mmtc.tlm.selection.TelemetrySelectionStrategy;
+
+import edu.jhuapl.sd.sig.mmtc.util.IsolatingUrlClassLoader;
+import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
+import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
+import org.apache.commons.configuration2.ConfigurationUtils;
+import org.apache.commons.configuration2.FileBasedConfiguration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+/**
+ * Defines a wrapper of the configuration parameters for the entire time correlation. These include the
+ * parameters read from the TimeCorrelationConfigProperties.xml file, the options provided buy a user from
+ * the command line, Ground Station Map associations, and the SCLK Partition Map associations.
+ *
+ * Functions in this class also provide access to each item in the TimeCorrelationConfigProperties.xml
+ * configuration parameters file.
+ */
+public abstract class MmtcConfig {
+    private static final String BASE_CONFIG_FILENAME = "TimeCorrelationConfigProperties-base.xml";
+
+    private static final Set<String> BUILT_IN_TLM_SOURCES = new HashSet<>(Collections.singletonList("rawTlmTable"));
+
+    protected final Path mmtcHome;
+    protected final TimeCorrelationConfig timeCorrelationConfig;
+
+    protected GroundStationMap groundStationMap;
+    protected SclkPartitionMap sclkPartitionMap;
+
+    private static final Logger logger = LogManager.getLogger();
+
+    public MmtcConfig() throws Exception {
+        logger.debug("Loading configuration");
+
+        this.mmtcHome = Paths.get(System.getenv("MMTC_HOME")).toAbsolutePath();
+        this.timeCorrelationConfig = new TimeCorrelationXmlPropertiesConfig();
+
+        if (! timeCorrelationConfig.load()) {
+            throw new MmtcException("Error loading " + timeCorrelationConfig.getPath());
+        }
+
+        this.groundStationMap = new GroundStationMap(getGroundStationMapPath());
+        if (!groundStationMap.load()) {
+            throw new MmtcException("Error loading " + groundStationMap.getPath());
+        }
+        logger.info("Loaded ground stations map " + groundStationMap.getPath());
+
+        this.sclkPartitionMap = new SclkPartitionMap(getSclkPartitionMapPath());
+        if (!sclkPartitionMap.load()) {
+            throw new MmtcException("Error loading " + sclkPartitionMap.getPath());
+        }
+        logger.info("Loaded SCLK clock partition map " + sclkPartitionMap.getPath());
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Time Correlation config file contents:\n");
+        builder.append("--------------------------------------\n");
+        builder.append(ConfigurationUtils.toString(timeCorrelationConfig.getConfig()));
+        builder.append("\n--------------------------------------\n");
+        return builder.toString();
+    }
+
+    /**
+     * Use Java ServiceLoader to find and load a telemetry source
+     */
+    protected TelemetrySource initTlmSource() throws Exception {
+        TelemetrySource tlmSource = null;
+
+        if (BUILT_IN_TLM_SOURCES.contains(getTelemetrySourceName())) {
+            // load tlm plugin from mmtc-core implementation already available to classloaders via current classpath
+            final ServiceLoader<TelemetrySource> tlmSourceLoader = ServiceLoader.load(TelemetrySource.class);
+
+            for (TelemetrySource tlmSourceCandidate : tlmSourceLoader) {
+                logger.debug("Found telemetry source candidate: {}", tlmSourceCandidate.getName());
+                if (tlmSourceCandidate.getName().equals(getTelemetrySourceName())) {
+                    tlmSource = tlmSourceCandidate;
+                    break;
+                }
+            }
+        } else {
+            final Path pluginJarPath;
+
+            try (Stream<Path> files = Files.list(getTelemetrySourcePluginDirectory())) {
+                List<Path> results = files.filter(p -> p.toString().endsWith(".jar"))
+                        .filter(p -> p.getFileName().toString().startsWith(getTelemetrySourcePluginJarPrefix()))
+                        .collect(Collectors.toList());
+
+                if (results.size() != 1) {
+                    throw new MmtcException(String.format("A unique plugin jar was not found at the given location: %d matching jars found at %s", results.size(), getTelemetrySourcePluginDirectory()));
+                }
+
+                pluginJarPath = results.get(0);
+            }
+
+            // load tlm plugin from an external jar
+            logger.info("Loading telemetry source implementation from {}", pluginJarPath);
+
+            final URL[] urls = { pluginJarPath.toAbsolutePath().toUri().toURL() };
+
+            // not closing this classloader here, because if we did, further classes won't be able to be loaded from the jar file
+            URLClassLoader cl = new IsolatingUrlClassLoader(urls);
+            final ServiceLoader<TelemetrySource> tlmSourceLoader = ServiceLoader.load(TelemetrySource.class, cl);
+
+            for (TelemetrySource tlmSourceCandidate : tlmSourceLoader) {
+                logger.debug("Found telemetry source candidate: {}", tlmSourceCandidate.getName());
+                if (tlmSourceCandidate.getName().equals(getTelemetrySourceName())) {
+                    tlmSource = tlmSourceCandidate;
+                    break;
+                }
+            }
+        }
+
+        if (tlmSource == null) {
+            throw new MmtcException(String.format("Cannot find telemetry source with name %s; please check configuration and plugin availability", getTelemetrySourceName()));
+        }
+
+        logger.info("Loaded telemetry source {}", tlmSource.getName());
+        return tlmSource;
+    }
+
+    /**
+     * Checks if a key is present in timeCorrelationConfig.
+     *
+     * @param key The full name of the config key in TimeCorrelationConfigProperties.xml
+     * @return true or false, depending on whether the key is present with a non-empty value
+     */
+    public boolean containsKey(String key) {
+        return timeCorrelationConfig.getConfig().containsKey(key) && (! timeCorrelationConfig.getConfig().getString(key).isEmpty());
+    }
+
+    /**
+     * Retrieves from the Ground Stations Map file the associations between Path ID and ground station ID.
+     * Converts a Path ID received from query metadata or ground receipt header to the equivalent Ground Station
+     * antenna (e.g., Path ID 14 = DSS-14 = Goldstone 70m dish). This can also relate to testbeds and front end
+     * processors.
+     *
+     * @param pathId the path identifier to be associated with a station ID
+     * @return the ground station ID
+     * @throws MmtcException if the ground station is not found
+     */
+    public String getStationId(int pathId) throws MmtcException {
+        return groundStationMap.getStationId(pathId);
+    }
+
+    /**
+     * Retrieves from the SCLK Partition Map File the start times of each SCLK partition defined for the
+     * mission and then determines which partition the supplied ERT falls into.
+     *
+     * @param groundReceiptTime the ERT associated with the partition
+     * @return the SCLK clock partition number associated with the ERT
+     */
+    public int getSclkPartition(OffsetDateTime groundReceiptTime) {
+        return sclkPartitionMap.getSclkPartition(groundReceiptTime);
+    }
+
+    /**
+     * Gets the name of the mission from configuration parameters.
+     * @return the name of the mission as a string
+     */
+    public String getMissionName() {
+        return timeCorrelationConfig.getConfig().getString("missionName");
+    }
+
+    /**
+     * Gets the NAIF assigned spacecraft ID from configuration parameters. This is usually the same as the
+     * SANA assigned ID, except with a negative sign attached to it.
+     *
+     * @return the assigned NAIF spacecraft ID for the mission
+     */
+    public int getNaifSpacecraftId() {
+        return timeCorrelationConfig.getConfig().getInt("spice.naifSpacecraftId");
+    }
+
+    /**
+     * Get the number of time correlation data samples designated to constitute a sample set.
+     *
+     * @return the number of samples per set
+     */
+    public int getSamplesPerSet() {
+        return timeCorrelationConfig.getConfig().getInt("telemetry.samplesPerSet");
+    }
+
+    /**
+     * Get the number of samples separating the target sample from the supplemental sample for the mission. This
+     * value is usually fixed for a mission. The target sample is the sample being used for time correlation; however it
+     * does not contain its own SCLK values. The SCLK values are contained in a succeding sample called the Supplemental
+     * Sample. Usually (but not always), the Supplemental Sample immediately follows the Target Sample so this value is
+     * usually 1.
+     *
+     * @return the index of the supplemental sample as an offset from the target sample
+     */
+    public int getSupplementalSampleOffset() {
+        return timeCorrelationConfig.getConfig().getInt("telemetry.supplementalSampleOffset");
+    }
+
+    /**
+     * Get the maximum virtual channel frame counter value a frame can be assigned before the next frame's virtual
+     * channel frame index is assigned zero. Depending on mission, this can range anywhere from a few hundred to 
+     * a few million, so MMTC needs to know when to expect a VCFC rollover.
+     * 
+     * @return the maximum virtual channel frame counter value before the counter rolls over to 0
+     */
+    public int getVcfcMaxValue() {
+        return timeCorrelationConfig.getConfig().getInt("telemetry.vcfcMaxValue");
+    }
+
+    /*
+     * Gets the spacecraft's maximum MCFC value, after which the counter will roll back to 0 and begin
+     * counting anew.
+     *
+     * @return the spacecraft maximum MCFC value
+     */
+    public int getMcfcMaxValue() {
+        return timeCorrelationConfig.getConfig().getInt("telemetry.mcfcMaxValue");
+    }
+
+    public boolean containsAllNonEmptyKeys(String... keys) {
+        for (String k : keys) {
+            if (! containsNonEmptyKey(k)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /*
+     * Checks the underlying file configuration for the presence of a non-empty key
+     *
+     * @return whether the key exists and is not empty
+     */
+    public boolean containsNonEmptyKey(String key) {
+        return timeCorrelationConfig.getConfig().containsKey(key) && (! getString(key).trim().isEmpty());
+    }
+
+    /**
+     * Creates a container in the form of a map that holds the SPICE kernels to load.
+     * @return a map containing the types and paths of each SPICE kernel
+     * @throws MmtcException if the list of kernels to load could not be obtained from configuration data
+     */
+    public Map<String, String> getKernelsToLoad() throws MmtcException {
+        // the fact that this is a LinkedHashMap is important, as it means iteration over the map will proceed in insertion-order
+        Map<String, String> kernels = new LinkedHashMap<>();
+
+        // Input metakernel
+        if (timeCorrelationConfig.getConfig().containsKey("spice.kernel.mk.path")) {
+            kernels.put(timeCorrelationConfig.getConfig().getString("spice.kernel.mk.path"), "mk");
+        }
+
+        // Get the path to the SCLK kernel. This will be the highest versioned SCLK kernel that matches
+        // the file pattern given in the configuration parameters, unless spice.kernel.sclk.inputPathOverride
+        // is set in the configuration parameters. The inputPathOverride parameter overrides the normal
+        // previous SCLK kernel search.
+        kernels.put(getInputSclkKernelPath().toString(), "sclk");
+
+        // Leap seconds kernel
+        if (timeCorrelationConfig.getConfig().containsKey("spice.kernel.lsk.path")) {
+            kernels.put(timeCorrelationConfig.getConfig().getString("spice.kernel.lsk.path"), "lsk");
+        }
+
+        List<String> illegalCommas = new ArrayList<>();
+        String key;
+        String[] paths;
+
+        // SPK kernels
+        key = "spice.kernel.spk.path";
+        for (String spk : timeCorrelationConfig.getConfig().getStringArray(key)) {
+            if (spk.isEmpty()) {
+                illegalCommas.add(key);
+                break;
+            }
+            kernels.put(spk, "spk");
+        }
+
+        // PCK kernels
+        key = "spice.kernel.pck.path";
+        for (String pck : timeCorrelationConfig.getConfig().getStringArray(key)) {
+            if (pck.isEmpty()) {
+                illegalCommas.add(key);
+                break;
+            }
+            kernels.put(pck, "pck");
+        }
+
+        // FK kernels
+        key = "spice.kernel.fk.path";
+        for (String fk : timeCorrelationConfig.getConfig().getStringArray(key)) {
+            if (fk.isEmpty()) {
+                illegalCommas.add(key);
+                break;
+            }
+            kernels.put(fk, "fk");
+        }
+
+        if (!illegalCommas.isEmpty()) {
+            String message = "The following kernel configuration options contain consecutive and/or trailing commas. These configurations are allowed to contain one or more paths separated by commas; however, they are not allowed to contain empty paths. This means they must not contain multiple commas in a row (even if the commas are separated by whitespace or line breaks), and they must not end with a comma.";
+            for (String config : illegalCommas) {
+                message += "\n  " + config;
+            }
+            logger.fatal(message);
+            throw new MmtcException("Consecutive or trailing commas in kernel configurations");
+        }
+
+        return kernels;
+    }
+
+    public String getTelemetrySourceName() {
+        return timeCorrelationConfig.getConfig().getString("telemetry.source.name");
+    }
+
+    public Path getTelemetrySourcePluginDirectory() {
+        return Paths.get(timeCorrelationConfig.getConfig().getString("telemetry.source.pluginDirectory")).toAbsolutePath();
+    }
+
+    public String getTelemetrySourcePluginJarPrefix() {
+        return timeCorrelationConfig.getConfig().getString("telemetry.source.pluginJarPrefix");
+    }
+
+    /**
+     * Gets the upper clock drift rate threshold for the Contact Filter
+     * @return the clock drift rate delta upper threshold for the contact filter.
+     */
+    public double getContactFilterDeltaUpperThreshold() {
+        return timeCorrelationConfig.getConfig().getDouble("filter.contact.deltaUpperThreshold");
+    }
+
+    /**
+     * Gets the lower clock drift rate threshold for the Contact Filter.
+     * @return the clock change rate delta lower threshold for the contact filter.
+     */
+    public double getContactFilterDeltaLowerThreshold() {
+        return timeCorrelationConfig.getConfig().getDouble("filter.contact.deltaLowerThreshold");
+    }
+
+    /**
+     * Gets the minimum data rate in bits per second that a sample must have been received at in order
+     * to be used in time correlation as passed through the Minimum Data Rate Filter.
+     * @return the minimum accepted data rate
+     */
+    public int getDataRateFilterMinRateBps() {
+        return timeCorrelationConfig.getConfig().getInt("filter.dataRate.minDataRateBps");
+    }
+
+    /**
+     * Gets the maximum data rate in bits per second that a sample must have been received at in order
+     * to be used in time correlation as passed through the Maximum Data Rate Filter.
+     * @return the maximum accepted data rate
+     */
+    public int getDataRateFilterMaxRateBps() {
+        return timeCorrelationConfig.getConfig().getInt("filter.dataRate.maxDataRateBps");
+    }
+
+    /**
+     * Gets the maximum allowed variance from the delta between the first two samples and the deltas 
+     * between all consecutive sample pairs that are allowed to pass the ERT Filter. Example: If the delta between
+     * sample 0 and sample 1 is x seconds, all subsequent deltas must be (x ± maxDeltaVarianceSec) seconds.
+     * @return the allowed variance of inter-sample deltas of ERT from the first ERT delta in seconds
+     */
+    public double getErtFilterMaxDeltaVarianceSec() {
+        return timeCorrelationConfig.getConfig().getDouble("filter.ert.maxDeltaVarianceSec");
+    }
+
+    /**
+     * Gets the maximum allowed variance from the delta between the first two samples and the deltas 
+     * between all consecutive sample pairs that are allowed to pass the SCLK Filter. Example: If the delta between
+     * sample 0 and sample 1 is x seconds, all subsequent deltas must be (x ± maxDeltaVarianceSec) seconds.
+     * @return the allowed variance of inter-sample deltas of SCLK from the first SCLK delta in seconds
+     */
+    public double getSclkFilterMaxDeltaVarianceSec() {
+        return timeCorrelationConfig.getConfig().getDouble("filter.sclk.maxDeltaVarianceSec");
+    }
+
+    /**
+     * Gets the set of ground station IDs from which data may be received for time correlation.
+     * @return the list of ground station IDs
+     */
+    public String[] getGroundStationFilterPathIds() {
+        return timeCorrelationConfig.getConfig().getStringArray("filter.groundStation.pathIds");
+    }
+
+    /**
+     * Gets the location of the output Raw Telemetry Table.
+     * @return the path to the output Raw Telemetry Table
+     */
+    public Path getRawTelemetryTablePath() {
+        return ensureAbsolute(Paths.get(timeCorrelationConfig.getConfig().getString("table.rawTelemetryTable.path")));
+    }
+
+    public Path ensureAbsolute(Path path) {
+        if (! path.isAbsolute()) {
+            return mmtcHome.resolve(path);
+        }
+        return path;
+    }
+
+    /**
+     * Indicates whether the VCID filter is enabled. Note that this method does not throw if the VCID filter is missing
+     * from the configuration file altogether.
+     * 
+     * @return true if the VCID filter is enabled in the configuration file, false
+     *         otherwise (including if an exception occurs while reading the
+     *         configuration)
+     */
+    public boolean isVcidFilterEnabled() {
+        try {
+            return timeCorrelationConfig.getConfig().getBoolean("filter.vcid.enabled");
+        }
+        catch (Exception ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Gets the valid VCID groups.
+     * 
+     * @return the groups of valid VCIDs
+     * @throws MmtcException if the groups are not specified in the
+     *                                  configuration file, the value is empty, or the value contains
+     *                                  any values that are non-integers
+     */
+    public Collection<Set<Integer>> getVcidFilterValidVcidGroups() throws MmtcException {
+        return parseVcidGroups(timeCorrelationConfig, "filter.vcid.validVcidGroups");
+    }
+
+    protected static Collection<Set<Integer>> parseVcidGroups(TimeCorrelationConfig timeCorrelationConfig, String configKey) throws MmtcException {
+        final String vcidGroups;
+        try {
+            vcidGroups = timeCorrelationConfig.getConfig().getString(configKey).trim();
+        } catch (NoSuchElementException e) {
+            throw new MmtcException("Missing configuration key: " + configKey);
+        }
+
+        try {
+            return parseVcidGroups(configKey, vcidGroups);
+        } catch (NumberFormatException e) {
+            throw new MmtcException(String.format("Configuration key %s must have a value that is non-empty and set to a semicolon-separated list of non-empty comma-separated lists of integers, e.g.: `1, 2; 3, 4`", configKey));
+        }
+    }
+
+    /**
+     * Parses VCID groups from the list of lists contained in the configuration file.  The expected format of the VCID
+     * groups is a semicolon-separated list of comma-separated lists, e.g.: "0, 6, 7; 5" which parses to one set containing
+     * 0, 6, and 7; and a second set containing only 5.
+     *
+     * @param configKey the config key
+     * @param configValue the config value, formatted as described above
+     * @return a collection of sets, each set representing a valid combination of VCIDs that can be used for time correlation
+     * @throws MmtcException if the format assumptions are violated
+     */
+    protected static Collection<Set<Integer>> parseVcidGroups(String configKey, String configValue) throws MmtcException {
+        final List<Set<Integer>> ret = new ArrayList<>();
+
+        final String formatError = String.format("Configuration key %s must have a value that is non-empty and set to a semicolon-separated list of non-empty comma-separated lists of integers, e.g.: `1 \\, 2 ; 3 \\, 4`", configKey);
+
+        configValue = configValue.trim();
+
+        if (configValue.isEmpty()) {
+            throw new MmtcException(formatError);
+        }
+
+        for (String group : configValue.split(";")) {
+            group = group.trim();
+            Set<Integer> parsedVcidGroup = Arrays.stream(group.split(","))
+                    .map(String::trim)
+                    .map(Integer::parseInt)
+                    .collect(Collectors.toSet());
+
+            if (parsedVcidGroup.isEmpty()) {
+                throw new MmtcException(formatError);
+            }
+
+            ret.add(parsedVcidGroup);
+        }
+
+        if (ret.isEmpty()) {
+            throw new MmtcException(formatError);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Gets the location of the output RunHistoryFile
+     * @return the path to the input and output RunHistoryFile
+     */
+    public Path getRunHistoryFilePath() {
+        return ensureAbsolute(Paths.get(timeCorrelationConfig.getConfig().getString("table.runHistoryFile.path")));
+    }
+
+    /**
+     * Gets the location of the output Summary Table.
+     * @return the path to the input and output Summary Table
+     */
+    public Path getSummaryTablePath() {
+        return ensureAbsolute(Paths.get(timeCorrelationConfig.getConfig().getString("table.summaryTable.path")));
+    }
+
+    /**
+     * Gets the location of the output Time History File.
+     * @return the path to the output Time History File
+     */
+    public Path getTimeHistoryFilePath() {
+        return ensureAbsolute(Paths.get(timeCorrelationConfig.getConfig().getString("table.timeHistoryFile.path")));
+    }
+
+    public List<String> getTimeHistoryFileExcludeColumns() {
+        return Arrays.asList(timeCorrelationConfig.getConfig().getStringArray("table.timeHistoryFile.excludeColumns"));
+    }
+
+    /**
+     * Get the path to the input SCLK kernel, which can be one of the
+     * following:
+     *<p>
+     *  (1) the latest or most recent kernel as determined by the version
+     *      number in the filename, or
+     *  (2) the path to an SCLK kernel explicitly given by the user
+     *<p>
+     *  In the case of (1), returns the full file specification of the latest
+     *  SCLK kernel in the indicated directory. Assumes that the
+     *  lexicographically greatest filename is the latest. Filters files in the
+     *  directory assuming that the SCLK kernel filenames begin with the the
+     *  SCLK kernel basename and ends with the SCLK kernel file suffix (usually
+     *  .tsc) provided in configuration parameters.
+     *<p>
+     *  In the case of (2), the path given in the inputPathOverride configuration parameter is used.
+     *  This is intended for use in test environments only or in anomalous circumstances. It can cause
+     *  problems with filename duplication if used operationally.
+     *
+     * @return the path to the input SCLK kernel
+     * @throws MmtcException if the SCLK path is invalid
+     */
+    public Path getInputSclkKernelPath() throws MmtcException {
+        Path result;
+
+        // If the SCLK override is specified by this configuration parameter, use that SCLK kernel.
+        // Otherwise, find the SCLK in the directory with the latest version number and use it.
+        if (timeCorrelationConfig.getConfig().containsKey("spice.kernel.sclk.inputPathOverride")) {
+            try {
+                result = Paths.get(timeCorrelationConfig.getConfig().getString(
+                        "spice.kernel.sclk.inputPathOverride"));
+            }
+            catch (InvalidPathException ex) {
+                throw new MmtcException("Invalid input SCLK kernel override path");
+            }
+        }
+        else {
+            final String sclkBaseName = timeCorrelationConfig.getConfig().getString(
+                    "spice.kernel.sclk.baseName");
+            final Path sclkDir = Paths.get(timeCorrelationConfig.getConfig().getString(
+                    "spice.kernel.sclk.kerneldir"));
+            final String namePattern = "glob:**/" + sclkBaseName + "*" + SclkKernel.FILE_SUFFIX;
+            final PathMatcher filter = sclkDir.getFileSystem().getPathMatcher(namePattern);
+            List<Path> sclkKernelPaths;
+
+            try (final Stream<Path> stream = Files.list(sclkDir)) {
+                sclkKernelPaths = stream.filter(filter::matches).sorted().collect(Collectors.toList());
+            } catch (IOException ex) {
+                throw new MmtcException("Unable to read SCLK kernel directory: " + sclkDir, ex);
+            }
+
+
+            if (sclkKernelPaths.size() > 0) {
+                result = sclkKernelPaths.get(sclkKernelPaths.size() - 1);
+            } else {
+                throw new MmtcException("Unable to find seed SCLK kernel in " + sclkDir);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Gets the directory to write the output SCLK Kernel to.
+     * @return the directory to write the SCLK Kernel to
+     */
+    public Path getSclkKernelOutputDir() {
+        return Paths.get(timeCorrelationConfig.getConfig().getString("spice.kernel.sclk.kerneldir"));
+    }
+
+    /**
+     * Gets the SCLK Kernel basename, i.e., the first and static part of the SCLK Kernel filename.
+     * For example, given "europaclipper_00000.tsc", "europaclipper" is the basename.
+     *
+     * @return the SCLK Kernel basename
+     */
+    public String getSclkKernelBasename() {
+        return timeCorrelationConfig.getConfig().getString("spice.kernel.sclk.baseName");
+    }
+
+    /**
+     * Gets the SCLK Kernel name separator. The separator is the character between the basename and the version number
+     * of the SCLK kernel. For example, given "europaclipper_00000.tsc", "_" (underscore) is the separator. Underscore
+     * is the default.
+     *
+     * @return the name separator
+     */
+    public String getSclkKernelSeparator() {
+        return timeCorrelationConfig.getConfig().getString("spice.kernel.sclk.separator", "_");
+    }
+
+    public boolean generateUniqueKernelCounters() {
+        if (containsNonEmptyKey("spice.kernel.sclk.uniqueKernelCounters")) {
+            return timeCorrelationConfig.getConfig().getBoolean("spice.kernel.sclk.uniqueKernelCounters");
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * Gets the parameter that specifies if an SCLK/SCET file is to be created. Default is to create it.
+     * @return the parameter
+     */
+    public boolean createSclkScetFile() {
+        return timeCorrelationConfig.getConfig().getBoolean("product.sclkScetFile.create", true);
+    }
+
+    /**
+     * Gets the directory to write the output SCLK/SCET file to.
+     * @return the directory to write the SCLK/SCET to
+     */
+    public Path getSclkScetOutputDir() {
+        return Paths.get(timeCorrelationConfig.getConfig().getString("product.sclkScetFile.dir"));
+    }
+
+    /**
+     * Gets the SCLK/SCET file basename, i.e., the first and static part of the SCLK Kernel filename.
+     * For example, given "europaclipper_00000.coeff", "europaclipper" is the basename.
+     *
+     * @return the SCLK/SCET file basename
+     */
+    public String getSclkScetFileBasename() {
+        return timeCorrelationConfig.getConfig().getString("product.sclkScetFile.baseName");
+    }
+
+    /**
+     * Gets the SCLK/SCET file name separator. The separator is the character between the basename and the version number
+     * of the file. For example, given "europaclipper_00000.coeff", "_" (underscore) is the separator. Underscore is
+     * the default.
+     *
+     * @return the name separator
+     */
+    public String getSclkScetFileSeparator() {
+        return timeCorrelationConfig.getConfig().getString("product.sclkScetFile.separator", "_");
+    }
+
+    /**
+     * Get the SCLK/SCET file type suffix.
+     * For example, given "europaclipper_00000.coeff", ".coeff" is the suffix.
+     * NOTE: Unlike the SCLK Kernel, there is no standard or convention as to what this should be.
+     *
+     * @return the SCLK/SCET file type suffix
+     */
+    public String getSclkScetFileSuffix() {
+        return timeCorrelationConfig.getConfig().getString("product.sclkScetFile.suffix");
+    }
+
+    /**
+     * Gets the number of days to look back into the SCLK kernel from the current time for
+     * purposes of computing the predicted clock change rate. The number of days may contain
+     * a fractional part.
+     *
+     * @return the number of days to look back
+     */
+    public Double getPredictedClkRateLookBackDays() {
+        return timeCorrelationConfig.getConfig().getDouble("compute.tdtG.rate.predicted.lookBackDays");
+    }
+
+    /**
+     * Gets the maximum number of hours to look back into the SCLK kernel from the current time for
+     * purposes of computing the predicted clock change rate. This specifies how far back is too far
+     * in finding the previous time correlation in computing Predicted CLKRATE. This value is read-in
+     * from the config parameters as a floating point type representing days, multiplied by 24 to produce
+     * hours, and then the fractional part truncated to the integer whole hour.
+     *
+     * @return the maximum number of hours to look back
+     */
+    public Integer getMaxPredictedClkRateLookBackHours() {
+        Float maxLookBack = timeCorrelationConfig.getConfig().getFloat("compute.tdtG.rate.predicted.maxLookBackDays") * 24;
+        return new Integer(maxLookBack.intValue());
+    }
+
+    /**
+     * Gets the maximum error, in milliseconds, that can be computed for TDT(S) before indicating a warning in
+     * the TimeHistoryFile
+     * @return the error threshold for TDT(S)
+     */
+    public Optional<Double> getTdtSErrorWarningThresholdMs() {
+        if (timeCorrelationConfig.getConfig().containsKey("compute.tdtS.threshold.errorMsecWarning")) {
+            return Optional.of(timeCorrelationConfig.getConfig().getDouble("compute.tdtS.threshold.errorMsecWarning"));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Gets the number of digits to which the SCET fraction of second is to be written in an SCLK/SCET file.
+     * @return the number decimal digits to write
+     */
+    public Integer getSclkScetScetUtcPrecision() {
+        return timeCorrelationConfig.getConfig().getInt("product.sclkScetFile.scetUtcPrecision");
+    }
+
+    /**
+     * Gets the number of days past the correlation time in SCET (UTC) that the product should be valid/'applicable' for,
+     * which is written to the header of the file.  If the key is not specified, returns 0
+     *
+     * @return the number of days post-correlation that the file should be valid, or 0 if not specified
+     */
+    public Integer getSclkScetApplicableDurationDays() {
+        return timeCorrelationConfig.getConfig().getInt("product.sclkScetFile.applicableDurationDays", 0);
+    }
+
+
+    public enum SclkScetFileLeapSecondSclkRate {
+        ONE,
+        PRIOR_RATE,
+    }
+
+    /**
+     * Gets the mode that instructs MMTC how to set the SCLKRATE in SCLK-SCET files.  The two options are 'PRIOR_RATE',
+     * which reuses the SCLKRATE from the record just before the leap second entry pair for the second leap second entry,
+     * or 'ONE' which simply assigns a 1.0 rate to the second leap second entry.
+     *
+     * @return the SCLK-SCET leap second clock change rate mode, or PRIOR_RATE if not specified
+     */
+    public SclkScetFileLeapSecondSclkRate getSclkScetLeapSecondRateMode() {
+        final String mode = timeCorrelationConfig.getConfig().getString("product.sclkScetFile.leapSecondSclkRateMode", "PRIOR_RATE");
+        return SclkScetFileLeapSecondSclkRate.valueOf(mode);
+
+    }
+
+    /**
+     * Gets the number of digits to which the SCET fraction of second is to be written in the Time History File.
+     * @return the number decimal digits to write
+     */
+    public Integer getTimeHistoryFileScetUtcPrecision() {
+        return timeCorrelationConfig.getConfig().getInt("table.timeHistoryFile.scetUtcPrecision");
+    }
+
+    /**
+     * Gets the full name of the spacecraft.
+     * @return the name of the spacecraft as a string
+     */
+    public String getSpacecraftName() {
+        return timeCorrelationConfig.getConfig().getString("spacecraftName");
+    }
+
+    /**
+     * Gets the SANA-assigned Spacecraft ID (SCID).
+     * @return the spacecraft ID
+     */
+    public int getSpacecraftId() {
+        return timeCorrelationConfig.getConfig().getInt("spacecraft.id");
+    }
+
+    /**
+     * Gets the spacecraft internal time delay. This is the number of seconds (usually a fraction of a second) delay in
+     * the spacecraft systems that affects a frame radiation SCLK.
+     *
+     * @return the spacecraft time delay in seconds
+     */
+    public double getSpacecraftTimeDelaySec() {
+        return timeCorrelationConfig.getConfig().getDouble("spacecraft.timeDelaySec");
+    }
+
+    /**
+     * Gets the Bit Delay-Bit Rate Error. If the spacecraft timestamps the
+     * transmission starting at a specific part of the frame, but the ground station
+     * timestamps the receipt starting at a different part of the frame, then the
+     * correlated times will be offset by a "Bit Rate Error" time delay. This delay
+     * can be computed from the downlink rate and the bit offset between the parts
+     * of the frame that the spacecraft and the ground station use.
+     * 
+     * This method gets the configuration value that represents that bit offset.
+     *
+     * @return the bit offset between the parts of the frame that the spacecraft and
+     *         the ground station use
+     */
+    public double getFrameErtBitOffsetError() {
+        return timeCorrelationConfig.getConfig().getDouble("spacecraft.frameErtBitOffsetError");
+    }
+
+    /**
+     * Gets the mission ID. This is used in the SCLK/SCET file and is often, but not always, the same as the
+     * spacecraft name.
+     *
+     * @return the mission ID used in the SCLK/SCET file
+     */
+    public int getMissionId() {
+        return timeCorrelationConfig.getConfig().getInt("missionId");
+    }
+
+    /**
+     * Gets the value for the DATA_SET_ID field to be included in the header of the SCLK/SCET file.
+     * @return the dataset ID used in the SCLK/SCET file
+     */
+    public String getDataSetId() {
+        return timeCorrelationConfig.getConfig().getString("product.sclkScetFile.datasetId");
+    }
+
+    /**
+     * Gets the value for the PRODUCER_ID field to be included in the header of the SCLK/SCET file.
+     * @return the producer ID used in the SCLK/SCET file
+     */
+    public String getProducerId() {
+        return timeCorrelationConfig.getConfig().getString("product.sclkScetFile.producerId");
+    }
+
+    /**
+     * Gets the directory to which the optional Uplink Command File is to be written.
+     * @return the Uplink Command File output directory
+     */
+    public String getUplinkCmdFileDir() {
+        return timeCorrelationConfig.getConfig().getString("product.uplinkCmdFile.outputDir");
+    }
+
+    /**
+     * Gets the Uplink Command file basename, i.e., the first and static part of the filename.
+     * For example, given "uplinkCmd1577130458.csv", "uplinkCmd" is the basename.
+     *
+     * @return the SCLK/SCET file basename
+     */
+    public String getUplinkCmdFileBasename() {
+        return timeCorrelationConfig.getConfig().getString("product.uplinkCmdFile.baseName");
+    }
+
+    // Config parameters associated with the time correlation (TK) packet.
+
+    /**
+     * Returns the time window in seconds surrounding a TK Oscillator Temperature telemetry point that can be
+     * included in a query. It is the seconds +/- precision of a SCET query value in which the query can be found.
+     * Values for the telemetry point outside of this window will not match.
+     *
+     * If not set, the default value is 600 seconds (10 minutes.)
+     *
+     * @return the time window in seconds
+     */
+    public int getTkOscTempWindowSec()  {
+        return timeCorrelationConfig.getConfig().getInt("telemetry.tkOscTempWindowSec", 600);
+    }
+
+    /**
+     * Returns the number of seconds after the SCET of a selected telemetry point containing one
+     * of the static time correlation parameters in which the data item is considered valid. The desired
+     * TLM point may not be available at exactly the ERT queried. This allows a query for the telemetry
+     * point at ERT +/- [this value].
+     *
+     * If not set, the default value is 600 seconds (10 minutes.)
+     *
+     * @return the time in seconds within which a TK parameter TLM point may be queried.
+     */
+    public int getTkParmWindowSec() {
+        return timeCorrelationConfig.getConfig().getInt("telemetry.tkParmWindowSec", 600);
+    }
+
+    /**
+     * Gets the full file specification (directory/name) of the input Ground Stations Map file.
+     * @return the ground station map file path
+     */
+    public Path getGroundStationMapPath() {
+        return Paths.get(timeCorrelationConfig.getConfig().getString("groundStationMap.path"));
+    }
+
+    /**
+     * Gets the full file specification (directory/name) of the input SCLK Partition Map file.
+     * @return the SCLK partition map file path
+     */
+    public Path getSclkPartitionMapPath() {
+        return Paths.get(timeCorrelationConfig.getConfig().getString("sclkPartitionMap.path"));
+    }
+
+    public List<String> getValidOscillatorIds() {
+        if (! containsNonEmptyKey("spacecraft.oscillatorIds")) {
+            return Collections.emptyList();
+        } else {
+            return Arrays.asList(getStringArray("spacecraft.oscillatorIds"));
+        }
+    }
+
+    /**
+     * Returns the number of ticks per second measured by the onboard Spacecraft Clock (SCLK). This is
+     * also called the "subseconds modulus", "SCLK modulus", or the "tick rate". In most missions,
+     * this value is based on the resolution of the GNC clock and is given in the SCLK01_MODULI_ss
+     * field of the input SCLK kernel; however, in some cases (e.g., Europa Clipper) it is added to the
+     * time correlation packets by another subsystem (e.g., the radio) after they are created using a
+     * different value. For purposes of computing TF Offset, the subseconds modulus must be that matches
+     * the SCLK clock used for time correlation.
+     *
+     * @return the subseconds modulus in ticks per second
+     */
+    public Integer getSclkModulusOverride() {
+        // If this parameter is not found or cannot be retrieved, handle the exception and return a null value.
+        try {
+            return timeCorrelationConfig.getConfig().getInt("spacecraft.sclkModulusOverride");
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+
+    /**
+     * Gets the pattern that is used to parse ERTs from query metadata and to write ERT to the RawTlmTable in calendar
+     * string date/time form (e.g., ISO DOY format: "yyyy-DDD'T'HH:mm:ss.SSSSSS").
+     *
+     * @return the calendar string format from configuration parameters
+     */
+    public String getRawTlmTableDateTimePattern() {
+        return timeCorrelationConfig.getConfig().getString("table.rawTelemetryTable.dateTimePattern");
+    }
+
+    public boolean getRawTlmTableReadDownlinkDataRate() {
+        return timeCorrelationConfig.getConfig().getBoolean("telemetry.source.plugin.rawTlmTable.readDownlinkDataRate");
+    }
+
+    public String getString(String key) {
+        return timeCorrelationConfig.getConfig().getString(key);
+    }
+
+    public Boolean getBoolean(String key) {
+        return timeCorrelationConfig.getConfig().getBoolean(key);
+    }
+
+    public int getInt(String key) {
+        return timeCorrelationConfig.getConfig().getInt(key);
+    }
+
+    public String[] getStringArray(String key) {
+        return timeCorrelationConfig.getConfig().getStringArray(key);
+    }
+
+    /**
+     * Returns the number of ticks per second measured by the onboard Spacecraft Clock (SCLK). This is
+     * also called the "subseconds modulus", "SCLK modulus", or the "tick rate". In most missions,
+     * this value is based on the resolution of the GNC clock and is given in the SCLK01_MODULI_ss
+     * field of the input SCLK kernel; however, in some cases (e.g., Europa Clipper) it is added to the
+     * time correlation packets by another subsystem (e.g., the radio) after they are created using a
+     * different value. For purposes of computing TF Offset, the subseconds modulus must be that which
+     * matches the SCLK clock used for time correlation.
+     *
+     * The default is to read the subseconds modulus from the SCLK Kernel. However, if the optional
+     * spacecraft.sclkModulusOverride configuration parameter is provided, it reads it from the
+     * configuration parameter.
+     *
+     * @return the subseconds modulus in ticks per second for the configured NAIF spacecraft ID
+     * @throws TimeConvertException if the value could not be obtained from the SCLK Kernel
+     */
+    public Integer getTkSclkFineTickModulus() throws TimeConvertException {
+        int tk_sclk_fine_tick_modulus = getSclkModulusOverride();
+
+        if (tk_sclk_fine_tick_modulus == -1) {
+            tk_sclk_fine_tick_modulus = TimeConvert.getSclkKernelTickRate(getNaifSpacecraftId());
+            logger.info("Read TF Offset SCLK subseconds modulus of " + tk_sclk_fine_tick_modulus + " from SCLK Kernel.");
+        } else {
+            logger.info("Read TF Offset SCLK subseconds modulus of " + tk_sclk_fine_tick_modulus + " from configuration parameters.");
+        }
+
+        return tk_sclk_fine_tick_modulus;
+    }
+
+    public TelemetrySelectionStrategy.SampleSetBuildingStrategy getSampleSetBuildingStrategy() {
+        return TelemetrySelectionStrategy.SampleSetBuildingStrategy.valueOf(
+                timeCorrelationConfig.getConfig().getString("telemetry.sampleSetBuildingStrategy")
+        );
+    }
+
+    public int getSamplingSampleSetBuildingStrategyQueryWidthMinutes() {
+        return timeCorrelationConfig.getConfig().getInt("telemetry.sampleSetBuildingStrategy.sampling.queryWidthMinutes");
+    }
+
+    public int getSamplingSampleSetBuildingStrategySamplingRateMinutes() {
+        return timeCorrelationConfig.getConfig().getInt("telemetry.sampleSetBuildingStrategy.sampling.samplingRateMinutes");
+    }
+
+    /**
+     * Method used for up-front validation of the presence of all required keys in TimeCorrelationAppConfig.xml. This is
+     * intended to be used with the standard base config found at {$TK_CONFIG_PATH}/examples/TimeCorrelationConfigProperties-base.xml,
+     * but any valid XML config can technically be used.
+     *
+     * @throws MmtcException if there are missing keys, or if the baseline config cannot be parsed.
+     */
+    public void validate() throws MmtcException {
+        final ArrayList<String> missingKeys = new ArrayList<>();
+        FileBasedConfiguration activeConf = timeCorrelationConfig.getConfig();
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = null;
+        try {
+            builder = factory.newDocumentBuilder();
+        } catch (ParserConfigurationException e) {
+            throw new MmtcException("Failed to initialize a new DocumentBuilder while attempting to validate the configuration file.");
+        }
+
+        // Parse TimeCorrelationConfigProperties-base.xml
+        ClassLoader classLoader = TimeCorrelationAppConfig.class.getClassLoader();
+        try (InputStream stream = classLoader.getResourceAsStream(BASE_CONFIG_FILENAME)) {
+            Document document = builder.parse(stream);
+            document.getDocumentElement().normalize();
+            NodeList nodeList = document.getElementsByTagName("entry");
+            for (int i = 0; i < nodeList.getLength(); i++) {
+                Node node = nodeList.item(i);
+
+                if (node.getNodeType() == Node.ELEMENT_NODE) {
+                    Element element = (Element) node;
+                    if (!activeConf.containsKey(element.getAttribute("key"))) {
+                        missingKeys.add(element.getAttribute("key"));
+                    }
+                }
+            }
+        } catch (SAXException | IOException e) {
+            throw new MmtcException(String.format("Failed to validate the configuration file against %s,", BASE_CONFIG_FILENAME), e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        if (missingKeys.isEmpty()) {
+            logger.info(String.format("All required config keys validated against %s successfully.", BASE_CONFIG_FILENAME));
+        } else {
+            throw new MmtcException(String.format("Failed to validate TimeCorrelationConfigProperties.xml, missing %d required key(s): %s",missingKeys.size(), missingKeys));
+        }
+    }
+
+
+    private static final List<String> REQD_SCLK_SCET_CONFIG_KEY_GROUP = Arrays.asList(
+            "product.sclkScetFile.create",
+            "product.sclkScetFile.dir",
+            "product.sclkScetFile.baseName",
+            "product.sclkScetFile.separator",
+            "product.sclkScetFile.suffix",
+            "product.sclkScetFile.datasetId",
+            "product.sclkScetFile.producerId",
+            "product.sclkScetFile.scetUtcPrecision"
+    );
+
+    private static final List<String> REQD_UPLINK_CMD_FILE_CONFIG_KEY_GROUP = Arrays.asList(
+            "product.uplinkCmdFile.create",
+            "product.uplinkCmdFile.outputDir",
+            "product.uplinkCmdFile.baseName"
+    );
+
+    public void validateSclkScetConfiguration() throws MmtcException {
+        List<String> missingKeys = checkForMissingKeysInGroup(REQD_SCLK_SCET_CONFIG_KEY_GROUP);
+
+        if (! missingKeys.isEmpty()) {
+            throw new MmtcException("SCLK-SCET operations require the following keys to be set: " + missingKeys.toString());
+        }
+    }
+
+    public void validateUplinkCmdFileConfiguration() throws MmtcException {
+        List<String> missingKeys = checkForMissingKeysInGroup(REQD_UPLINK_CMD_FILE_CONFIG_KEY_GROUP);
+
+        if (! missingKeys.isEmpty()) {
+            throw new MmtcException("Uplink command file operations require the following keys to be set: " + missingKeys.toString());
+        }
+    }
+
+    private List<String> checkForMissingKeysInGroup(List<String> requiredKeys) {
+        List<String> missingKeys = new ArrayList();
+
+        for (String key : requiredKeys) {
+            if (! timeCorrelationConfig.getConfig().containsKey(key)) {
+                missingKeys.add(key);
+            }
+        }
+
+        return missingKeys;
+    }
+}

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/MmtcSandboxCreatorConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/MmtcSandboxCreatorConfig.java
@@ -1,0 +1,45 @@
+package edu.jhuapl.sd.sig.mmtc.cfg;
+
+import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
+import edu.jhuapl.sd.sig.mmtc.tlm.TelemetrySource;
+import org.apache.commons.cli.*;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class MmtcSandboxCreatorConfig extends MmtcConfig {
+    private final TelemetrySource telemetrySource;
+    private final Path newSandboxPath;
+
+    public MmtcSandboxCreatorConfig(String... args) throws Exception {
+        super();
+        this.telemetrySource = this.initTlmSource();
+
+        final Options opts = new Options();
+        opts.addOption("h", "help", false, "Print this message.");
+
+        final CommandLineParser parser = new DefaultParser();
+        final CommandLine cmdLine = parser.parse(opts, args);
+
+        if (cmdLine.hasOption("h") || cmdLine.hasOption("help")) {
+            final HelpFormatter help = new HelpFormatter();
+            final String helpFooter = "\nCreates a new MMTC sandbox at the given path, based on the configuration of this MMTC installation.";
+            help.printHelp("mmtc create-sandbox <new-sandbox-path>", "", opts, helpFooter);
+            System.exit(0);
+        }
+
+        if (cmdLine.getArgList().size() != 1) {
+            throw new MmtcException("Error parsing command line arguments.");
+        }
+
+        newSandboxPath = Paths.get(cmdLine.getArgList().get(0)).toAbsolutePath();
+    }
+
+    public Path getNewSandboxPath() {
+        return newSandboxPath;
+    }
+
+    public TelemetrySource getTelemetrySource() {
+        return telemetrySource;
+    }
+}

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/RollbackConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/RollbackConfig.java
@@ -1,0 +1,27 @@
+package edu.jhuapl.sd.sig.mmtc.cfg;
+
+import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
+import org.apache.commons.cli.*;
+
+public class RollbackConfig extends MmtcConfig {
+    public RollbackConfig(String... args) throws Exception {
+        super();
+
+        final Options opts = new Options();
+        opts.addOption("h", "help", false, "Print this message.");
+
+        final CommandLineParser parser = new DefaultParser();
+        final CommandLine cmdLine = parser.parse(opts, args);
+
+        if (cmdLine.hasOption("h") || cmdLine.hasOption("help")) {
+            final HelpFormatter help = new HelpFormatter();
+            final String helpFooter = "\nInvoke the interactive MMTC rollback feature on the console.  Takes no CLI arguments.";
+            help.printHelp("mmtc rollback", "", opts, helpFooter);
+            System.exit(0);
+        }
+
+        if (cmdLine.getArgList().size() != 0) {
+            throw new MmtcException("Error parsing command line arguments.");
+        }
+    }
+}

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/SclkPartitionMap.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/SclkPartitionMap.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -44,7 +45,7 @@ public class SclkPartitionMap extends AbstractConfig {
      * Class constructor
      * @param sclkPartionMapPath IN:the path to the SCLK partion map file
      */
-    public SclkPartitionMap(String sclkPartionMapPath) {
+    public SclkPartitionMap(Path sclkPartionMapPath) {
         super(sclkPartionMapPath);
     }
 
@@ -57,10 +58,11 @@ public class SclkPartitionMap extends AbstractConfig {
         try {
             logger.info("Loading SCLK Partition Map: " + this.path);
 
-            File file = new File(this.path);
-
-            CSVParser parser = CSVParser.parse(file, Charset.forName("utf-8"),
-                    CSVFormat.DEFAULT.withFirstRecordAsHeader().withTrim());
+            CSVParser parser = CSVParser.parse(
+                    this.path,
+                    Charset.forName("utf-8"),
+                    CSVFormat.DEFAULT.withFirstRecordAsHeader().withTrim()
+            );
 
             partitions = new TreeMap<>();
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/TimeCorrelationAppConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/TimeCorrelationAppConfig.java
@@ -1,72 +1,17 @@
 package edu.jhuapl.sd.sig.mmtc.cfg;
 
+import edu.jhuapl.sd.sig.mmtc.app.MmtcCli;
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
-import edu.jhuapl.sd.sig.mmtc.app.TimeCorrelationApp;
 import edu.jhuapl.sd.sig.mmtc.filter.TimeCorrelationFilter;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.nio.file.*;
-import java.time.OffsetDateTime;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import edu.jhuapl.sd.sig.mmtc.products.SclkKernel;
 import edu.jhuapl.sd.sig.mmtc.tlm.TelemetrySource;
-import edu.jhuapl.sd.sig.mmtc.tlm.selection.TelemetrySelectionStrategy;
-import edu.jhuapl.sd.sig.mmtc.util.IsolatingUrlClassLoader;
-
-import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
-import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
-import org.apache.commons.configuration2.ConfigurationUtils;
-import org.apache.commons.configuration2.FileBasedConfiguration;
 import org.apache.commons.configuration2.ex.ConversionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
+import java.time.OffsetDateTime;
+import java.util.*;
 
-/**
- * Defines a wrapper of the configuration parameters for the entire time correlation. These include the
- * parameters read from the TimeCorrelationConfigProperties.xml file, the options provided buy a user from
- * the command line, Ground Station Map associations, and the SCLK Partition Map associations.
- *
- * Functions in this class also provide access to each item in the TimeCorrelationConfigProperties.xml
- * configuration parameters file.
- */
-public class TimeCorrelationAppConfig {
-    private static final String BASE_CONFIG_FILENAME = "TimeCorrelationConfigProperties-base.xml";
-
-    private static final Set<String> BUILT_IN_TLM_SOURCES = new HashSet<>(Collections.singletonList("rawTlmTable"));
-
-    public String getCmdLineOptionValue(char shortOpt) {
-        return cmdLineConfig.getOptionValue(shortOpt);
-    }
-
-    public boolean cmdLineHasOption(char shortOpt) {
-        return cmdLineConfig.hasOption(shortOpt);
-    }
-
-    public enum ClockChangeRateMode {
-        COMPUTE_INTERPOLATED,
-        COMPUTE_PREDICTED,
-        ASSIGN,
-        ASSIGN_KEY,
-        NO_DRIFT
-    }
-
+public class TimeCorrelationAppConfig extends MmtcConfig{
     public static final String CONTACT_FILTER = "contact";
     public static final String MIN_DATARATE_FILTER = "minDataRate";
     public static final String MAX_DATARATE_FILTER = "maxDataRate";
@@ -78,32 +23,46 @@ public class TimeCorrelationAppConfig {
     public static final String VCID_FILTER = "vcid";
     public static final String CONSEC_MC_FRAME_FILTER = "consecutiveMasterChannelFrames";
 
-    private final CommandLineConfig cmdLineConfig;
-    private final TimeCorrelationConfig timeCorrelationConfig;
-    private final TelemetrySource telemetrySource;
-
-    private GroundStationMap groundStationMap;
-    private SclkPartitionMap sclkPartitionMap;
-    private ClockChangeRateMode clockChangeRateMode;
-    private double clockChangeRateAssignedValue;
-
-    private static final Logger logger = LogManager.getLogger();
     private static final ClockChangeRateMode defaultClockChangeRateMode = ClockChangeRateMode.COMPUTE_INTERPOLATED;
 
+    private static final Logger logger = LogManager.getLogger();
+
+    private final CorrelationCommandLineConfig cmdLineConfig;
+
+    private final TelemetrySource telemetrySource;
+
+    private ClockChangeRateMode clockChangeRateMode;
+
+    private double clockChangeRateAssignedValue;
+
+    public String getCmdLineOptionValue(char shortOpt) {
+        return cmdLineConfig.getOptionValue(shortOpt);
+    }
+
+    public boolean cmdLineHasOption(char shortOpt) {
+        return cmdLineConfig.hasOption(shortOpt);
+    }
+
+    public String[] getCliArgs() {
+        return this.cmdLineConfig.getArgs();
+    }
+
+    public enum ClockChangeRateMode {
+        COMPUTE_INTERPOLATED,
+        COMPUTE_PREDICTED,
+        ASSIGN,
+        ASSIGN_KEY,
+        NO_DRIFT
+    }
+
     public TimeCorrelationAppConfig(String... args) throws Exception {
-        logger.debug("Loading configuration");
-
-        this.timeCorrelationConfig = new TimeCorrelationXmlPropertiesConfig();
-
-        if (! timeCorrelationConfig.load()) {
-            throw new MmtcException("Error loading " + timeCorrelationConfig.getPath());
-        }
+        super();
 
         this.telemetrySource = this.initTlmSource();
 
-        this.cmdLineConfig = new CommandLineConfig(args, this.telemetrySource.getAdditionalCliArguments());
+        this.cmdLineConfig = new CorrelationCommandLineConfig(args, this.telemetrySource.getAdditionalCliArguments());
 
-        if (!cmdLineConfig.load()) {
+        if (! cmdLineConfig.load()) {
             throw new MmtcException("Error parsing command line arguments.");
         }
 
@@ -111,23 +70,10 @@ public class TimeCorrelationAppConfig {
         if (clockChangeRateMode == ClockChangeRateMode.ASSIGN) {
             setClockChangeRateAssignedValue();
         }
+
         if (clockChangeRateMode == ClockChangeRateMode.ASSIGN || clockChangeRateMode == ClockChangeRateMode.ASSIGN_KEY) {
-            logger.info(TimeCorrelationApp.USER_NOTICE, String.format("Assigned clock change rate: %f", clockChangeRateAssignedValue));
+            logger.info(MmtcCli.USER_NOTICE, String.format("Assigned clock change rate: %f", clockChangeRateAssignedValue));
         }
-
-        // These configuration items need to be created here because the configuration parameters must be loaded first.
-        this.groundStationMap = new GroundStationMap(getGroundStationMapPath());
-        this.sclkPartitionMap = new SclkPartitionMap(getSclkPartitionMapPath());
-
-        if (!groundStationMap.load()) {
-            throw new MmtcException("Error loading " + groundStationMap.getPath());
-        }
-        logger.info("Loaded ground stations map " + groundStationMap.getPath());
-
-        if (!sclkPartitionMap.load()) {
-            throw new MmtcException("Error loading " + sclkPartitionMap.getPath());
-        }
-        logger.info("Loaded SCLK clock partition map " + sclkPartitionMap.getPath());
 
         // todo would be ideal if config was immutable
         this.telemetrySource.applyConfiguration(this);
@@ -135,191 +81,9 @@ public class TimeCorrelationAppConfig {
         logger.debug(toString());
     }
 
-    public TimeCorrelationAppConfig() throws Exception {
-        // Minimal constructor for use during rollback
-        this.timeCorrelationConfig = new TimeCorrelationXmlPropertiesConfig();
-        this.telemetrySource = null;
-        this.cmdLineConfig = null;
-
-        if (! timeCorrelationConfig.load()) {
-            throw new MmtcException("Error loading " + timeCorrelationConfig.getPath());
-        }
-    }
 
     public TelemetrySource getTelemetrySource() {
         return telemetrySource;
-    }
-
-    /**
-     * Use Java ServiceLoader to find and load a telemetry source
-     */
-    private TelemetrySource initTlmSource() throws Exception {
-        TelemetrySource tlmSource = null;
-
-        if (BUILT_IN_TLM_SOURCES.contains(getTelemetrySourceName())) {
-            // load tlm plugin from mmtc-core implementation already available to classloaders via current classpath
-            final ServiceLoader<TelemetrySource> tlmSourceLoader = ServiceLoader.load(TelemetrySource.class);
-
-            for (TelemetrySource tlmSourceCandidate : tlmSourceLoader) {
-                logger.debug("Found telemetry source candidate: {}", tlmSourceCandidate.getName());
-                if (tlmSourceCandidate.getName().equals(getTelemetrySourceName())) {
-                    tlmSource = tlmSourceCandidate;
-                    break;
-                }
-            }
-        } else {
-            final Path pluginJarPath;
-
-            try (Stream<Path> files = Files.list(getTelemetrySourcePluginDirectory())) {
-                List<Path> results = files.filter(p -> p.toString().endsWith(".jar"))
-                        .filter(p -> p.getFileName().toString().startsWith(getTelemetrySourcePluginJarPrefix()))
-                        .collect(Collectors.toList());
-
-                if (results.size() != 1) {
-                    throw new MmtcException(String.format("A unique plugin jar was not found at the given location: %d matching jars found at %s", results.size(), getTelemetrySourcePluginDirectory()));
-                }
-
-                pluginJarPath = results.get(0);
-            }
-
-            // load tlm plugin from an external jar
-            logger.info("Loading telemetry source implementation from {}", pluginJarPath);
-
-            final URL[] urls = { pluginJarPath.toAbsolutePath().toUri().toURL() };
-
-            // not closing this classloader here, because if we did, further classes won't be able to be loaded from the jar file
-            URLClassLoader cl = new IsolatingUrlClassLoader(urls);
-            final ServiceLoader<TelemetrySource> tlmSourceLoader = ServiceLoader.load(TelemetrySource.class, cl);
-
-            for (TelemetrySource tlmSourceCandidate : tlmSourceLoader) {
-                logger.debug("Found telemetry source candidate: {}", tlmSourceCandidate.getName());
-                if (tlmSourceCandidate.getName().equals(getTelemetrySourceName())) {
-                    tlmSource = tlmSourceCandidate;
-                    break;
-                }
-            }
-        }
-
-        if (tlmSource == null) {
-            throw new MmtcException(String.format("Cannot find telemetry source with name %s; please check configuration and plugin availability", getTelemetrySourceName()));
-        }
-
-        logger.info("Loaded telemetry source {}", tlmSource.getName());
-        return tlmSource;
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("Time Correlation config file contents:\n");
-        builder.append("--------------------------------------\n");
-        builder.append(ConfigurationUtils.toString(timeCorrelationConfig.getConfig()));
-        builder.append("\n--------------------------------------\n");
-        return builder.toString();
-    }
-
-    /**
-     * Checks if a key is present in timeCorrelationConfig.
-     *
-     * @param key The full name of the config key in TimeCorrelationConfigProperties.xml
-     * @return true or false, depending on whether the key is present with a non-empty value
-     */
-    public boolean containsKey(String key) {
-        return timeCorrelationConfig.getConfig().containsKey(key) && (! timeCorrelationConfig.getConfig().getString(key).isEmpty());
-    }
-
-    /**
-     * Retrieves from the Ground Stations Map file the associations between Path ID and ground station ID.
-     * Converts a Path ID received from query metadata or ground receipt header to the equivalent Ground Station
-     * antenna (e.g., Path ID 14 = DSS-14 = Goldstone 70m dish). This can also relate to testbeds and front end
-     * processors.
-     *
-     * @param pathId the path identifier to be associated with a station ID
-     * @return the ground station ID
-     * @throws MmtcException if the ground station is not found
-     */
-    public String getStationId(int pathId) throws MmtcException {
-        return groundStationMap.getStationId(pathId);
-    }
-
-    /**
-     * Retrieves from the SCLK Partition Map File the start times of each SCLK partition defined for the
-     * mission and then determines which partition the supplied ERT falls into.
-     *
-     * @param groundReceiptTime the ERT associated with the partition
-     * @return the SCLK clock partition number associated with the ERT
-     */
-    public int getSclkPartition(OffsetDateTime groundReceiptTime) {
-        return sclkPartitionMap.getSclkPartition(groundReceiptTime);
-    }
-
-    /**
-     * The start time of the telemetry interval from which to query data for time correlation as supplied by
-     * the user in the command line arguments.
-     *
-     * @return the sampling interval start time supplied by the user
-     */
-    public OffsetDateTime getStartTime() {
-        return cmdLineConfig.getStartTime();
-    }
-
-    /**
-     * The stop time of the telemetry interval from which to query data for time correlation as supplied by
-     * the user in the command line arguments.
-     *
-     * @return the sampling interval stop time supplied by the user
-     */
-    public OffsetDateTime getStopTime() {
-        return cmdLineConfig.getStopTime();
-    }
-
-    /**
-     * Indicates if test mode is set.
-     *
-     * @return true if test mode is enabled
-     */
-    public boolean isTestMode() {
-        return cmdLineConfig.isTestMode();
-    }
-
-    /**
-     * Gets the one-way light travel time (OWLT) value supplied by the user in the command line options in a test venue.
-     *
-     * @return the OWLT to be used for time correlation
-     */
-    public double getTestModeOwlt() { return cmdLineConfig.getTestModeOwlt(); }
-
-    /**
-     * As is the case with the other filters, the contact filter can be enabled or
-     * disabled from the parameter file, which is the preferred way to do it.
-     * However, it can also be disabled from the command line with the
-     * --disable-contact-filter or -F command line option. The command line option
-     * overrides the configuration filter.contact.enabled paramter setting.
-     * 
-     * @return true if the contact filter is DISABLED, false if enabled
-     * @throws MmtcException if contact filter is not disabled from the
-     *                                  command line and is also missing from
-     *                                  application configuration
-     */
-    public boolean isContactFilterDisabled() throws MmtcException {
-        boolean isDisabled = true;
-        if(!cmdLineConfig.isContactFilterDisabled()) {
-            String filterName = TimeCorrelationAppConfig.CONTACT_FILTER;
-            try {
-                if (timeCorrelationConfig.getConfig().getBoolean(String.format("filter.%s.enabled", filterName))) {
-                    logger.info("Filter " + filterName + " is enabled.");
-                    isDisabled = false;
-                }
-                else {
-                    logger.info("Filter " + filterName + " is disabled.");
-                }
-            }
-            catch (NoSuchElementException ex) {
-                throw new MmtcException("Expected contact filter " + filterName +
-                        " is is not indicated configuration file", ex);
-            }
-        }
-        return isDisabled;
     }
 
     /**
@@ -337,7 +101,7 @@ public class TimeCorrelationAppConfig {
      * command line options. If no relevant command line options are passed in, then
      * this is determined by the configuration file. If no relevant option is found
      * in the configuration file, then this falls back to a default method.
-     * 
+     *
      * @throws MmtcException if the configuration file contains an
      *                                  invalid value for the clock change rate mode
      *                                  option.
@@ -408,180 +172,72 @@ public class TimeCorrelationAppConfig {
     }
 
     /**
-     * Gets the name of the mission from configuration parameters.
-     * @return the name of the mission as a string
+     * The start time of the telemetry interval from which to query data for time correlation as supplied by
+     * the user in the command line arguments.
+     *
+     * @return the sampling interval start time supplied by the user
      */
-    public String getMissionName() {
-        return timeCorrelationConfig.getConfig().getString("missionName");
+    public OffsetDateTime getStartTime() {
+        return cmdLineConfig.getStartTime();
     }
 
     /**
-     * Gets the NAIF assigned spacecraft ID from configuration parameters. This is usually the same as the
-     * SANA assigned ID, except with a negative sign attached to it.
+     * The stop time of the telemetry interval from which to query data for time correlation as supplied by
+     * the user in the command line arguments.
      *
-     * @return the assigned NAIF spacecraft ID for the mission
+     * @return the sampling interval stop time supplied by the user
      */
-    public int getNaifSpacecraftId() {
-        return timeCorrelationConfig.getConfig().getInt("spice.naifSpacecraftId");
+    public OffsetDateTime getStopTime() {
+        return cmdLineConfig.getStopTime();
     }
 
     /**
-     * Get the number of time correlation data samples designated to constitute a sample set.
+     * Indicates if test mode is set.
      *
-     * @return the number of samples per set
+     * @return true if test mode is enabled
      */
-    public int getSamplesPerSet() {
-        return timeCorrelationConfig.getConfig().getInt("telemetry.samplesPerSet");
+    public boolean isTestMode() {
+        return cmdLineConfig.isTestMode();
     }
 
     /**
-     * Get the number of samples separating the target sample from the supplemental sample for the mission. This
-     * value is usually fixed for a mission. The target sample is the sample being used for time correlation; however it
-     * does not contain its own SCLK values. The SCLK values are contained in a succeding sample called the Supplemental
-     * Sample. Usually (but not always), the Supplemental Sample immediately follows the Target Sample so this value is
-     * usually 1.
+     * Gets the one-way light travel time (OWLT) value supplied by the user in the command line options in a test venue.
      *
-     * @return the index of the supplemental sample as an offset from the target sample
+     * @return the OWLT to be used for time correlation
      */
-    public int getSupplementalSampleOffset() {
-        return timeCorrelationConfig.getConfig().getInt("telemetry.supplementalSampleOffset");
-    }
+    public double getTestModeOwlt() { return cmdLineConfig.getTestModeOwlt(); }
 
     /**
-     * Get the maximum virtual channel frame counter value a frame can be assigned before the next frame's virtual
-     * channel frame index is assigned zero. Depending on mission, this can range anywhere from a few hundred to 
-     * a few million, so MMTC needs to know when to expect a VCFC rollover.
-     * 
-     * @return the maximum virtual channel frame counter value before the counter rolls over to 0
-     */
-    public int getVcfcMaxValue() {
-        return timeCorrelationConfig.getConfig().getInt("telemetry.vcfcMaxValue");
-    }
-
-    /*
-     * Gets the spacecraft's maximum MCFC value, after which the counter will roll back to 0 and begin
-     * counting anew.
+     * As is the case with the other filters, the contact filter can be enabled or
+     * disabled from the parameter file, which is the preferred way to do it.
+     * However, it can also be disabled from the command line with the
+     * --disable-contact-filter or -F command line option. The command line option
+     * overrides the configuration filter.contact.enabled paramter setting.
      *
-     * @return the spacecraft maximum MCFC value
+     * @return true if the contact filter is DISABLED, false if enabled
+     * @throws MmtcException if contact filter is not disabled from the
+     *                                  command line and is also missing from
+     *                                  application configuration
      */
-    public int getMcfcMaxValue() {
-        return timeCorrelationConfig.getConfig().getInt("telemetry.mcfcMaxValue");
-    }
-
-    public boolean containsAllNonEmptyKeys(String... keys) {
-        for (String k : keys) {
-            if (! containsNonEmptyKey(k)) {
-                return false;
+    public boolean isContactFilterDisabled() throws MmtcException {
+        boolean isDisabled = true;
+        if (!cmdLineConfig.isContactFilterDisabled()) {
+            String filterName = TimeCorrelationAppConfig.CONTACT_FILTER;
+            try {
+                if (timeCorrelationConfig.getConfig().getBoolean(String.format("filter.%s.enabled", filterName))) {
+                    logger.info("Filter " + filterName + " is enabled.");
+                    isDisabled = false;
+                }
+                else {
+                    logger.info("Filter " + filterName + " is disabled.");
+                }
+            }
+            catch (NoSuchElementException ex) {
+                throw new MmtcException("Expected contact filter " + filterName +
+                        " is is not indicated configuration file", ex);
             }
         }
-
-        return true;
-    }
-
-    /*
-     * Checks the underlying file configuration for the presence of a non-empty key
-     *
-     * @return whether the key exists and is not empty
-     */
-    public boolean containsNonEmptyKey(String key) {
-        return timeCorrelationConfig.getConfig().containsKey(key) && (! getString(key).trim().isEmpty());
-    }
-
-    /**
-     * Creates a container in the form of a map that holds the SPICE kernels to load.
-     * @return a map containing the types and paths of each SPICE kernel
-     * @throws MmtcException if the list of kernels to load could not be obtained from configuration data
-     */
-    public Map<String, String> getKernelsToLoad() throws MmtcException {
-        Map<String, String> kernels = new LinkedHashMap<>();
-
-        // Input metakernel
-        if (timeCorrelationConfig.getConfig().containsKey("spice.kernel.mk.path")) {
-            kernels.put(timeCorrelationConfig.getConfig().getString("spice.kernel.mk.path"), "mk");
-        }
-
-        // Get the path to the SCLK kernel. This will be the highest versioned SCLK kernel that matches
-        // the file pattern given in the configuration parameters, unless spice.kernel.sclk.inputPathOverride
-        // is set in the configuration parameters. The inputPathOverride parameter overrides the normal
-        // previous SCLK kernel search.
-        kernels.put(getSclkKernelPath().toString(), "sclk");
-
-        // Leap seconds kernel
-        if (timeCorrelationConfig.getConfig().containsKey("spice.kernel.lsk.path")) {
-            kernels.put(timeCorrelationConfig.getConfig().getString("spice.kernel.lsk.path"), "lsk");
-        }
-
-        List<String> illegalCommas = new ArrayList<>();
-        String key;
-        String[] paths;
-
-        // SPK kernels
-        key = "spice.kernel.spk.path";
-        for (String spk : timeCorrelationConfig.getConfig().getStringArray(key)) {
-            if (spk.isEmpty()) {
-                illegalCommas.add(key);
-                break;
-            }
-            kernels.put(spk, "spk");
-        }
-
-        // PCK kernels
-        key = "spice.kernel.pck.path";
-        for (String pck : timeCorrelationConfig.getConfig().getStringArray(key)) {
-            if (pck.isEmpty()) {
-                illegalCommas.add(key);
-                break;
-            }
-            kernels.put(pck, "pck");
-        }
-
-        // FK kernels
-        key = "spice.kernel.fk.path";
-        for (String fk : timeCorrelationConfig.getConfig().getStringArray(key)) {
-            if (fk.isEmpty()) {
-                illegalCommas.add(key);
-                break;
-            }
-            kernels.put(fk, "fk");
-        }
-
-        if (!illegalCommas.isEmpty()) {
-            String message = "The following kernel configuration options contain consecutive and/or trailing commas. These configurations are allowed to contain one or more paths separated by commas; however, they are not allowed to contain empty paths. This means they must not contain multiple commas in a row (even if the commas are separated by whitespace or line breaks), and they must not end with a comma.";
-            for (String config : illegalCommas) {
-                message += "\n  " + config;
-            }
-            logger.fatal(message);
-            throw new MmtcException("Consecutive or trailing commas in kernel configurations");
-        }
-
-        return kernels;
-    }
-
-    public String getTelemetrySourceName() {
-        return timeCorrelationConfig.getConfig().getString("telemetry.source.name");
-    }
-
-    public Path getTelemetrySourcePluginDirectory() {
-        return Paths.get(timeCorrelationConfig.getConfig().getString("telemetry.source.pluginDirectory")).toAbsolutePath();
-    }
-
-    public String getTelemetrySourcePluginJarPrefix() {
-        return timeCorrelationConfig.getConfig().getString("telemetry.source.pluginJarPrefix");
-    }
-
-    /**
-     * Gets the telemetry source object. This is the abstract object that could be a telemetry server or a file.
-     *
-     * @return the URI of the SCLK/ERT data source
-     * @throws MmtcException if the telemetry source could not be determined
-     */
-    public URI getTelemetrySourceUri() throws MmtcException {
-        try {
-            return new URI(timeCorrelationConfig.getConfig().getString("telemetry.source.uri"));
-        }
-        catch (URISyntaxException ex) {
-            throw new MmtcException("Unable to parse URI", ex);
-        }
+        return isDisabled;
     }
 
     /**
@@ -625,672 +281,17 @@ public class TimeCorrelationAppConfig {
     }
 
     /**
-     * Gets the upper clock drift rate threshold for the Contact Filter
-     * @return the clock drift rate delta upper threshold for the contact filter.
-     */
-    public double getContactFilterDeltaUpperThreshold() {
-        return timeCorrelationConfig.getConfig().getDouble("filter.contact.deltaUpperThreshold");
-    }
-
-    /**
-     * Gets the lower clock drift rate threshold for the Contact Filter.
-     * @return the clock change rate delta lower threshold for the contact filter.
-     */
-    public double getContactFilterDeltaLowerThreshold() {
-        return timeCorrelationConfig.getConfig().getDouble("filter.contact.deltaLowerThreshold");
-    }
-
-    /**
-     * Gets the minimum data rate in bits per second that a sample must have been received at in order
-     * to be used in time correlation as passed through the Minimum Data Rate Filter.
-     * @return the minimum accepted data rate
-     */
-    public int getDataRateFilterMinRateBps() {
-        return timeCorrelationConfig.getConfig().getInt("filter.dataRate.minDataRateBps");
-    }
-
-    /**
-     * Gets the maximum data rate in bits per second that a sample must have been received at in order
-     * to be used in time correlation as passed through the Maximum Data Rate Filter.
-     * @return the maximum accepted data rate
-     */
-    public int getDataRateFilterMaxRateBps() {
-        return timeCorrelationConfig.getConfig().getInt("filter.dataRate.maxDataRateBps");
-    }
-
-    /**
-     * Gets the maximum allowed variance from the delta between the first two samples and the deltas 
-     * between all consecutive sample pairs that are allowed to pass the ERT Filter. Example: If the delta between
-     * sample 0 and sample 1 is x seconds, all subsequent deltas must be (x ± maxDeltaVarianceSec) seconds.
-     * @return the allowed variance of inter-sample deltas of ERT from the first ERT delta in seconds
-     */
-    public double getErtFilterMaxDeltaVarianceSec() {
-        return timeCorrelationConfig.getConfig().getDouble("filter.ert.maxDeltaVarianceSec");
-    }
-
-    /**
-     * Gets the maximum allowed variance from the delta between the first two samples and the deltas 
-     * between all consecutive sample pairs that are allowed to pass the SCLK Filter. Example: If the delta between
-     * sample 0 and sample 1 is x seconds, all subsequent deltas must be (x ± maxDeltaVarianceSec) seconds.
-     * @return the allowed variance of inter-sample deltas of SCLK from the first SCLK delta in seconds
-     */
-    public double getSclkFilterMaxDeltaVarianceSec() {
-        return timeCorrelationConfig.getConfig().getDouble("filter.sclk.maxDeltaVarianceSec");
-    }
-
-    /**
-     * Gets the set of ground station IDs from which data may be received for time correlation.
-     * @return the list of ground station IDs
-     */
-    public String[] getGroundStationFilterPathIds() {
-        return timeCorrelationConfig.getConfig().getStringArray("filter.groundStation.pathIds");
-    }
-
-    /**
-     * Gets the location of the output Raw Telemetry Table.
-     * @return the path to the output Raw Telemetry Table
-     */
-    public URI getRawTelemetryTableUri() {
-        try {
-            return new URI(timeCorrelationConfig.getConfig().getString("table.rawTelemetryTable.uri"));
-        } catch (URISyntaxException ex) {
-            // throw new MmtcException("Unable to parse URI", ex);
-            throw new RuntimeException(ex);
-        }
-    }
-
-    /**
-     * Indicates whether the VCID filter is enabled. Note that this method does not throw if the VCID filter is missing
-     * from the configuration file altogether.
-     * 
-     * @return true if the VCID filter is enabled in the configuration file, false
-     *         otherwise (including if an exception occurs while reading the
-     *         configuration)
-     */
-    public boolean isVcidFilterEnabled() {
-        try {
-            return timeCorrelationConfig.getConfig().getBoolean("filter.vcid.enabled");
-        }
-        catch (Exception ex) {
-            return false;
-        }
-    }
-
-    /**
-     * Gets the valid VCID groups.
-     * 
-     * @return the groups of valid VCIDs
-     * @throws MmtcException if the groups are not specified in the
-     *                                  configuration file, the value is empty, or the value contains
-     *                                  any values that are non-integers
-     */
-    public Collection<Set<Integer>> getVcidFilterValidVcidGroups() throws MmtcException {
-        return parseVcidGroups(timeCorrelationConfig, "filter.vcid.validVcidGroups");
-    }
-
-    protected static Collection<Set<Integer>> parseVcidGroups(TimeCorrelationConfig timeCorrelationConfig, String configKey) throws MmtcException {
-        final String vcidGroups;
-        try {
-            vcidGroups = timeCorrelationConfig.getConfig().getString(configKey).trim();
-        } catch (NoSuchElementException e) {
-            throw new MmtcException("Missing configuration key: " + configKey);
-        }
-
-        try {
-            return parseVcidGroups(configKey, vcidGroups);
-        } catch (NumberFormatException e) {
-            throw new MmtcException(String.format("Configuration key %s must have a value that is non-empty and set to a semicolon-separated list of non-empty comma-separated lists of integers, e.g.: `1, 2; 3, 4`", configKey));
-        }
-    }
-
-    /**
-     * Parses VCID groups from the list of lists contained in the configuration file.  The expected format of the VCID
-     * groups is a semicolon-separated list of comma-separated lists, e.g.: "0, 6, 7; 5" which parses to one set containing
-     * 0, 6, and 7; and a second set containing only 5.
-     *
-     * @param configKey the config key
-     * @param configValue the config value, formatted as described above
-     * @return a collection of sets, each set representing a valid combination of VCIDs that can be used for time correlation
-     * @throws MmtcException if the format assumptions are violated
-     */
-    protected static Collection<Set<Integer>> parseVcidGroups(String configKey, String configValue) throws MmtcException {
-        final List<Set<Integer>> ret = new ArrayList<>();
-
-        final String formatError = String.format("Configuration key %s must have a value that is non-empty and set to a semicolon-separated list of non-empty comma-separated lists of integers, e.g.: `1 \\, 2 ; 3 \\, 4`", configKey);
-
-        configValue = configValue.trim();
-
-        if (configValue.isEmpty()) {
-            throw new MmtcException(formatError);
-        }
-
-        for (String group : configValue.split(";")) {
-            group = group.trim();
-            Set<Integer> parsedVcidGroup = Arrays.stream(group.split(","))
-                    .map(String::trim)
-                    .map(Integer::parseInt)
-                    .collect(Collectors.toSet());
-
-            if (parsedVcidGroup.isEmpty()) {
-                throw new MmtcException(formatError);
-            }
-
-            ret.add(parsedVcidGroup);
-        }
-
-        if (ret.isEmpty()) {
-            throw new MmtcException(formatError);
-        }
-
-        return ret;
-    }
-
-    /**
-     * Gets the location of the output RunHistoryFile
-     * @return the path to the input and output RunHistoryFile
-     * @throws MmtcException if the location cannot be accessed
-     */
-    public URI getRunHistoryFileUri() throws MmtcException {
-        try {
-            return new URI(timeCorrelationConfig.getConfig().getString("table.runHistoryFile.uri"));
-        }
-        catch (URISyntaxException ex) {
-            throw new MmtcException("Unable to parse URI", ex);
-        }
-    }
-
-    /**
-     * Gets the location of the output Time History File.
-     * @return the path to the output Time History File
-     */
-    public URI getTimeHistoryFileUri() {
-        try {
-            return new URI(timeCorrelationConfig.getConfig().getString("table.timeHistoryFile.uri"));
-        }
-        catch (URISyntaxException ex) {
-            throw new RuntimeException("Unable to parse URI", ex);
-        }
-    }
-
-    public List<String> getTimeHistoryFileExcludeColumns() {
-        return Arrays.asList(timeCorrelationConfig.getConfig().getStringArray("table.timeHistoryFile.excludeColumns"));
-    }
-
-    /**
-     * Get the path to the input SCLK kernel, which can be one of the
-     * following:
-     *<p>
-     *  (1) the latest or most recent kernel as determined by the version
-     *      number in the filename, or
-     *  (2) the path to an SCLK kernel explicitly given by the user
-     *<p>
-     *  In the case of (1), returns the full file specification of the latest
-     *  SCLK kernel in the indicated directory. Assumes that the
-     *  lexicographically greatest filename is the latest. Filters files in the
-     *  directory assuming that the SCLK kernel filenames begin with the the
-     *  SCLK kernel basename and ends with the SCLK kernel file suffix (usually
-     *  .tsc) provided in configuration parameters.
-     *<p>
-     *  In the case of (2), the path given in the inputPathOverride configuration parameter is used.
-     *  This is intended for use in test environments only or in anomalous circumstances. It can cause
-     *  problems with filename duplication if used operationally.
-     *
-     * @return the path to the input SCLK kernel
-     * @throws MmtcException if the SCLK path is invalid
-     */
-    public Path getSclkKernelPath() throws MmtcException {
-        Path result;
-
-        // If the SCLK override is specified by this configuration parameter, use that SCLK kernel.
-        // Otherwise, find the SCLK in the directory with the latest version number and use it.
-        if (timeCorrelationConfig.getConfig().containsKey("spice.kernel.sclk.inputPathOverride")) {
-            try {
-                result = Paths.get(timeCorrelationConfig.getConfig().getString(
-                        "spice.kernel.sclk.inputPathOverride"));
-            }
-            catch (InvalidPathException ex) {
-                throw new MmtcException("Invalid input SCLK kernel override path");
-            }
-        }
-        else {
-            final String sclkBaseName = timeCorrelationConfig.getConfig().getString(
-                    "spice.kernel.sclk.baseName");
-            final Path sclkDir = Paths.get(timeCorrelationConfig.getConfig().getString(
-                    "spice.kernel.sclk.kerneldir"));
-            final String namePattern = "glob:**/" + sclkBaseName + "*" + SclkKernel.FILE_SUFFIX;
-            final PathMatcher filter = sclkDir.getFileSystem().getPathMatcher(namePattern);
-            List<Path> sclkKernelPaths;
-
-            try (final Stream<Path> stream = Files.list(sclkDir)) {
-                sclkKernelPaths = stream.filter(filter::matches).sorted().collect(Collectors.toList());
-            } catch (IOException ex) {
-                throw new MmtcException("Unable to read SCLK kernel directory: " + sclkDir, ex);
-            }
-
-
-            if (sclkKernelPaths.size() > 0) {
-                result = sclkKernelPaths.get(sclkKernelPaths.size() - 1);
-            } else {
-                throw new MmtcException("Unable to find seed SCLK kernel in " + sclkDir);
-            }
-        }
-
-        return result;
-    }
-
-    /**
-     * Gets the directory to write the output SCLK Kernel to.
-     * @return the directory to write the SCLK Kernel to
-     */
-    public Path getSclkKernelOutputDir() {
-        return Paths.get(timeCorrelationConfig.getConfig().getString("spice.kernel.sclk.kerneldir"));
-    }
-
-    /**
-     * Gets the SCLK Kernel basename, i.e., the first and static part of the SCLK Kernel filename.
-     * For example, given "europaclipper_00000.tsc", "europaclipper" is the basename.
-     *
-     * @return the SCLK Kernel basename
-     */
-    public String getSclkKernelBasename() {
-        return timeCorrelationConfig.getConfig().getString("spice.kernel.sclk.baseName");
-    }
-
-    /**
-     * Gets the SCLK Kernel name separator. The separator is the character between the basename and the version number
-     * of the SCLK kernel. For example, given "europaclipper_00000.tsc", "_" (underscore) is the separator. Underscore
-     * is the default.
-     *
-     * @return the name separator
-     */
-    public String getSclkKernelSeparator() {
-        return timeCorrelationConfig.getConfig().getString("spice.kernel.sclk.separator", "_");
-    }
-
-    public boolean generateUniqueKernelCounters() {
-        if (containsNonEmptyKey("spice.kernel.sclk.uniqueKernelCounters")) {
-            return timeCorrelationConfig.getConfig().getBoolean("spice.kernel.sclk.uniqueKernelCounters");
-        } else {
-            return true;
-        }
-    }
-
-    /**
-     * Gets the parameter that specifies if an SCLK/SCET file is to be created. Default is to create it.
-     * @return the parameter
-     */
-    public boolean createSclkScetFile() {
-        return timeCorrelationConfig.getConfig().getBoolean("product.sclkScetFile.create", true);
-    }
-
-    /**
-     * Gets the directory to write the output SCLK/SCET file to.
-     * @return the directory to write the SCLK/SCET to
-     */
-    public Path getSclkScetOutputDir() {
-        return Paths.get(timeCorrelationConfig.getConfig().getString("product.sclkScetFile.dir"));
-    }
-
-    /**
-     * Gets the SCLK/SCET file basename, i.e., the first and static part of the SCLK Kernel filename.
-     * For example, given "europaclipper_00000.coeff", "europaclipper" is the basename.
-     *
-     * @return the SCLK/SCET file basename
-     */
-    public String getSclkScetFileBasename() {
-        return timeCorrelationConfig.getConfig().getString("product.sclkScetFile.baseName");
-    }
-
-    /**
-     * Gets the SCLK/SCET file name separator. The separator is the character between the basename and the version number
-     * of the file. For example, given "europaclipper_00000.coeff", "_" (underscore) is the separator. Underscore is
-     * the default.
-     *
-     * @return the name separator
-     */
-    public String getSclkScetFileSeparator() {
-        return timeCorrelationConfig.getConfig().getString("product.sclkScetFile.separator", "_");
-    }
-
-    /**
-     * Get the SCLK/SCET file type suffix.
-     * For example, given "europaclipper_00000.coeff", ".coeff" is the suffix.
-     * NOTE: Unlike the SCLK Kernel, there is no standard or convention as to what this should be.
-     *
-     * @return the SCLK/SCET file type suffix
-     */
-    public String getSclkScetFileSuffix() {
-        return timeCorrelationConfig.getConfig().getString("product.sclkScetFile.suffix");
-    }
-
-    /**
-     * Gets the number of days to look back into the SCLK kernel from the current time for
-     * purposes of computing the predicted clock change rate. The number of days may contain
-     * a fractional part.
-     *
-     * @return the number of days to look back
-     */
-    public Double getPredictedClkRateLookBackDays() {
-        return timeCorrelationConfig.getConfig().getDouble("compute.tdtG.rate.predicted.lookBackDays");
-    }
-
-    /**
-     * Gets the maximum number of hours to look back into the SCLK kernel from the current time for
-     * purposes of computing the predicted clock change rate. This specifies how far back is too far
-     * in finding the previous time correlation in computing Predicted CLKRATE. This value is read-in
-     * from the config parameters as a floating point type representing days, multiplied by 24 to produce
-     * hours, and then the fractional part truncated to the integer whole hour.
-     *
-     * @return the maximum number of hours to look back
-     */
-    public Integer getMaxPredictedClkRateLookBackHours() {
-        Float maxLookBack = timeCorrelationConfig.getConfig().getFloat("compute.tdtG.rate.predicted.maxLookBackDays") * 24;
-        return new Integer(maxLookBack.intValue());
-    }
-
-    /**
-     * Gets the maximum error, in milliseconds, that can be computed for TDT(S) before indicating a warning in
-     * the TimeHistoryFile
-     * @return the error threshold for TDT(S)
-     */
-    public Optional<Double> getTdtSErrorWarningThresholdMs() {
-        if (timeCorrelationConfig.getConfig().containsKey("compute.tdtS.threshold.errorMsecWarning")) {
-            return Optional.of(timeCorrelationConfig.getConfig().getDouble("compute.tdtS.threshold.errorMsecWarning"));
-        } else {
-            return Optional.empty();
-        }
-    }
-
-    /**
-     * Gets the number of digits to which the SCET fraction of second is to be written in an SCLK/SCET file.
-     * @return the number decimal digits to write
-     */
-    public Integer getSclkScetScetUtcPrecision() {
-        return timeCorrelationConfig.getConfig().getInt("product.sclkScetFile.scetUtcPrecision");
-    }
-
-    /**
-     * Gets the number of days past the correlation time in SCET (UTC) that the product should be valid/'applicable' for,
-     * which is written to the header of the file.  If the key is not specified, returns 0
-     *
-     * @return the number of days post-correlation that the file should be valid, or 0 if not specified
-     */
-    public Integer getSclkScetApplicableDurationDays() {
-        return timeCorrelationConfig.getConfig().getInt("product.sclkScetFile.applicableDurationDays", 0);
-    }
-
-
-    public enum SclkScetFileLeapSecondSclkRate {
-        ONE,
-        PRIOR_RATE,
-    }
-
-    /**
-     * Gets the mode that instructs MMTC how to set the SCLKRATE in SCLK-SCET files.  The two options are 'PRIOR_RATE',
-     * which reuses the SCLKRATE from the record just before the leap second entry pair for the second leap second entry,
-     * or 'ONE' which simply assigns a 1.0 rate to the second leap second entry.
-     *
-     * @return the SCLK-SCET leap second clock change rate mode, or PRIOR_RATE if not specified
-     */
-    public SclkScetFileLeapSecondSclkRate getSclkScetLeapSecondRateMode() {
-        final String mode = timeCorrelationConfig.getConfig().getString("product.sclkScetFile.leapSecondSclkRateMode", "PRIOR_RATE");
-        return SclkScetFileLeapSecondSclkRate.valueOf(mode);
-
-    }
-
-    /**
-     * Gets the number of digits to which the SCET fraction of second is to be written in the Time History File.
-     * @return the number decimal digits to write
-     */
-    public Integer getTimeHistoryFileScetUtcPrecision() {
-        return timeCorrelationConfig.getConfig().getInt("table.timeHistoryFile.scetUtcPrecision");
-    }
-
-    /**
-     * Gets the full name of the spacecraft.
-     * @return the name of the spacecraft as a string
-     */
-    public String getSpacecraftName() {
-        return timeCorrelationConfig.getConfig().getString("spacecraftName");
-    }
-
-    /**
-     * Gets the SANA-assigned Spacecraft ID (SCID).
-     * @return the spacecraft ID
-     */
-    public int getSpacecraftId() {
-        return timeCorrelationConfig.getConfig().getInt("spacecraft.id");
-    }
-
-    /**
-     * Gets the spacecraft internal time delay. This is the number of seconds (usually a fraction of a second) delay in
-     * the spacecraft systems that affects a frame radiation SCLK.
-     *
-     * @return the spacecraft time delay in seconds
-     */
-    public double getSpacecraftTimeDelaySec() {
-        return timeCorrelationConfig.getConfig().getDouble("spacecraft.timeDelaySec");
-    }
-
-    /**
-     * Gets the Bit Delay-Bit Rate Error. If the spacecraft timestamps the
-     * transmission starting at a specific part of the frame, but the ground station
-     * timestamps the receipt starting at a different part of the frame, then the
-     * correlated times will be offset by a "Bit Rate Error" time delay. This delay
-     * can be computed from the downlink rate and the bit offset between the parts
-     * of the frame that the spacecraft and the ground station use.
-     * 
-     * This method gets the configuration value that represents that bit offset.
-     *
-     * @return the bit offset between the parts of the frame that the spacecraft and
-     *         the ground station use
-     */
-    public double getFrameErtBitOffsetError() {
-        return timeCorrelationConfig.getConfig().getDouble("spacecraft.frameErtBitOffsetError");
-    }
-
-    /**
-     * Gets the mission ID. This is used in the SCLK/SCET file and is often, but not always, the same as the
-     * spacecraft name.
-     *
-     * @return the mission ID used in the SCLK/SCET file
-     */
-    public int getMissionId() {
-        return timeCorrelationConfig.getConfig().getInt("missionId");
-    }
-
-    /**
-     * Gets the value for the DATA_SET_ID field to be included in the header of the SCLK/SCET file.
-     * @return the dataset ID used in the SCLK/SCET file
-     */
-    public String getDataSetId() {
-        return timeCorrelationConfig.getConfig().getString("product.sclkScetFile.datasetId");
-    }
-
-    /**
-     * Gets the value for the PRODUCER_ID field to be included in the header of the SCLK/SCET file.
-     * @return the producer ID used in the SCLK/SCET file
-     */
-    public String getProducerId() {
-        return timeCorrelationConfig.getConfig().getString("product.sclkScetFile.producerId");
-    }
-
-    /**
      * Indicates if an optional Uplink Command File is to be created. This can be specified in either the command line
      * or in configuration parameters. Command line overrides the configuration parameter.
      *
      * @return true if an Uplink Command File is to be created
      */
-    public boolean createUplinkCmdFile() {
+    public boolean isCreateUplinkCmdFile() {
         if (cmdLineConfig.isGenerateCmdFile()) {
             return true;
         } else {
             return timeCorrelationConfig.getConfig().getBoolean("product.uplinkCmdFile.create", false);
         }
-    }
-
-    /**
-     * Gets the directory to which the optional Uplink Command File is to be written.
-     * @return the Uplink Command File output directory
-     */
-    public String getUplinkCmdFileDir() {
-        return timeCorrelationConfig.getConfig().getString("product.uplinkCmdFile.outputDir");
-    }
-
-    /**
-     * Gets the Uplink Command file basename, i.e., the first and static part of the filename.
-     * For example, given "uplinkCmd1577130458.csv", "uplinkCmd" is the basename.
-     *
-     * @return the SCLK/SCET file basename
-     */
-    public String getUplinkCmdFileBasename() {
-        return timeCorrelationConfig.getConfig().getString("product.uplinkCmdFile.baseName");
-    }
-
-    // Config parameters associated with the time correlation (TK) packet.
-
-    /**
-     * Returns the time window in seconds surrounding a TK Oscillator Temperature telemetry point that can be
-     * included in a query. It is the seconds +/- precision of a SCET query value in which the query can be found.
-     * Values for the telemetry point outside of this window will not match.
-     *
-     * If not set, the default value is 600 seconds (10 minutes.)
-     *
-     * @return the time window in seconds
-     */
-    public int getTkOscTempWindowSec()  {
-        return timeCorrelationConfig.getConfig().getInt("telemetry.tkOscTempWindowSec", 600);
-    }
-
-    /**
-     * Returns the number of seconds after the SCET of a selected telemetry point containing one
-     * of the static time correlation parameters in which the data item is considered valid. The desired
-     * TLM point may not be available at exactly the ERT queried. This allows a query for the telemetry
-     * point at ERT +/- [this value].
-     *
-     * If not set, the default value is 600 seconds (10 minutes.)
-     *
-     * @return the time in seconds within which a TK parameter TLM point may be queried.
-     */
-    public int getTkParmWindowSec() {
-        return timeCorrelationConfig.getConfig().getInt("telemetry.tkParmWindowSec", 600);
-    }
-
-    /**
-     * Gets the full file specification (director/name) of the input Ground Stations Map file.
-     * @return the ground station map file path
-     */
-    public String getGroundStationMapPath() {
-        return timeCorrelationConfig.getConfig().getString("groundStationMap.path");
-    }
-
-    /**
-     * Gets the full file specification (director/name) of the input SCLK Partition Map file.
-     * @return the SCLK partition map file path
-     */
-    public String getSclkPartitionMapPath() {
-        return timeCorrelationConfig.getConfig().getString("sclkPartitionMap.path");
-    }
-
-    public List<String> getValidOscillatorIds() {
-        if (! containsNonEmptyKey("spacecraft.oscillatorIds")) {
-            return Collections.emptyList();
-        } else {
-            return Arrays.asList(getStringArray("spacecraft.oscillatorIds"));
-        }
-    }
-
-    /**
-     * Returns the number of ticks per second measured by the onboard Spacecraft Clock (SCLK). This is
-     * also called the "subseconds modulus", "SCLK modulus", or the "tick rate". In most missions,
-     * this value is based on the resolution of the GNC clock and is given in the SCLK01_MODULI_ss
-     * field of the input SCLK kernel; however, in some cases (e.g., Europa Clipper) it is added to the
-     * time correlation packets by another subsystem (e.g., the radio) after they are created using a
-     * different value. For purposes of computing TF Offset, the subseconds modulus must be that matches
-     * the SCLK clock used for time correlation.
-     *
-     * @return the subseconds modulus in ticks per second
-     */
-    public Integer getSclkModulusOverride() {
-        // If this parameter is not found or cannot be retrieved, handle the exception and return a null value.
-        try {
-            return timeCorrelationConfig.getConfig().getInt("spacecraft.sclkModulusOverride");
-        } catch (Exception e) {
-            return -1;
-        }
-    }
-
-    /**
-     * Gets the pattern that is used to parse ERTs from query metadata and to write ERT to the RawTlmTable in calendar
-     * string date/time form (e.g., ISO DOY format: "yyyy-DDD'T'HH:mm:ss.SSSSSS").
-     *
-     * @return the calendar string format from configuration parameters
-     */
-    public String getRawTlmTableDateTimePattern() {
-        return timeCorrelationConfig.getConfig().getString("table.rawTelemetryTable.dateTimePattern");
-    }
-
-    public boolean getRawTlmTableReadDownlinkDataRate() {
-        return timeCorrelationConfig.getConfig().getBoolean("telemetry.source.plugin.rawTlmTable.readDownlinkDataRate");
-    }
-
-    public String getString(String key) {
-        return timeCorrelationConfig.getConfig().getString(key);
-    }
-
-    public Boolean getBoolean(String key) {
-        return timeCorrelationConfig.getConfig().getBoolean(key);
-    }
-
-    public int getInt(String key) {
-        return timeCorrelationConfig.getConfig().getInt(key);
-    }
-
-    public String[] getStringArray(String key) {
-        return timeCorrelationConfig.getConfig().getStringArray(key);
-    }
-
-    /**
-     * Returns the number of ticks per second measured by the onboard Spacecraft Clock (SCLK). This is
-     * also called the "subseconds modulus", "SCLK modulus", or the "tick rate". In most missions,
-     * this value is based on the resolution of the GNC clock and is given in the SCLK01_MODULI_ss
-     * field of the input SCLK kernel; however, in some cases (e.g., Europa Clipper) it is added to the
-     * time correlation packets by another subsystem (e.g., the radio) after they are created using a
-     * different value. For purposes of computing TF Offset, the subseconds modulus must be that which
-     * matches the SCLK clock used for time correlation.
-     *
-     * The default is to read the subseconds modulus from the SCLK Kernel. However, if the optional
-     * spacecraft.sclkModulusOverride configuration parameter is provided, it reads it from the
-     * configuration parameter.
-     *
-     * @return the subseconds modulus in ticks per second for the configured NAIF spacecraft ID
-     * @throws TimeConvertException if the value could not be obtained from the SCLK Kernel
-     */
-    public Integer getTkSclkFineTickModulus() throws TimeConvertException {
-        int tk_sclk_fine_tick_modulus = getSclkModulusOverride();
-
-        if (tk_sclk_fine_tick_modulus == -1) {
-            tk_sclk_fine_tick_modulus = TimeConvert.getSclkKernelTickRate(getNaifSpacecraftId());
-            logger.info("Read TF Offset SCLK subseconds modulus of " + tk_sclk_fine_tick_modulus + " from SCLK Kernel.");
-        } else {
-            logger.info("Read TF Offset SCLK subseconds modulus of " + tk_sclk_fine_tick_modulus + " from configuration parameters.");
-        }
-
-        return tk_sclk_fine_tick_modulus;
-    }
-
-    public TelemetrySelectionStrategy.SampleSetBuildingStrategy getSampleSetBuildingStrategy() {
-        return TelemetrySelectionStrategy.SampleSetBuildingStrategy.valueOf(
-                timeCorrelationConfig.getConfig().getString("telemetry.sampleSetBuildingStrategy")
-        );
-    }
-
-    public int getSamplingSampleSetBuildingStrategyQueryWidthMinutes() {
-        return timeCorrelationConfig.getConfig().getInt("telemetry.sampleSetBuildingStrategy.sampling.queryWidthMinutes");
-    }
-
-    public int getSamplingSampleSetBuildingStrategySamplingRateMinutes() {
-        return timeCorrelationConfig.getConfig().getInt("telemetry.sampleSetBuildingStrategy.sampling.samplingRateMinutes");
     }
 
     /**
@@ -1301,116 +302,14 @@ public class TimeCorrelationAppConfig {
      */
     public void validate() throws MmtcException {
         // Validate that all required config keys are present
-        validateRequiredConfigKeys(BASE_CONFIG_FILENAME);
+        super.validate();
 
         if (createSclkScetFile()) {
             validateSclkScetConfiguration();
         }
 
-        if (createUplinkCmdFile()) {
+        if (isCreateUplinkCmdFile()) {
             validateUplinkCmdFileConfiguration();
         }
-    }
-
-    /**
-     * Method used for up-front validation of the presence of all required keys in TimeCorrelationAppConfig.xml. This is
-     * intended to be used with the standard base config found at {$TK_CONFIG_PATH}/examples/TimeCorrelationConfigProperties-base.xml,
-     * but any valid XML config can technically be used.
-     * @param baseConfigPath Path to the baseline config file that the active config will be compared against
-     *
-     * @throws MmtcException if there are missing keys, or if the baseline config cannot be parsed.
-     */
-    public void validateRequiredConfigKeys(String baseConfigPath) throws MmtcException {
-        final ArrayList<String> missingKeys = new ArrayList<>();
-        FileBasedConfiguration activeConf = timeCorrelationConfig.getConfig();
-
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = null;
-        try {
-            builder = factory.newDocumentBuilder();
-        } catch (ParserConfigurationException e) {
-            throw new MmtcException("Failed to initialize a new DocumentBuilder while attempting to validate the configuration file.");
-        }
-
-        // Parse TimeCorrelationConfigProperties-base.xml
-        ClassLoader classLoader = TimeCorrelationAppConfig.class.getClassLoader();
-        try (InputStream stream = classLoader.getResourceAsStream(baseConfigPath)) {
-            Document document = builder.parse(stream);
-            document.getDocumentElement().normalize();
-            NodeList nodeList = document.getElementsByTagName("entry");
-            for (int i = 0; i < nodeList.getLength(); i++) {
-                Node node = nodeList.item(i);
-
-                if (node.getNodeType() == Node.ELEMENT_NODE) {
-                    Element element = (Element) node;
-                    if (!activeConf.containsKey(element.getAttribute("key"))) {
-                        missingKeys.add(element.getAttribute("key"));
-                    }
-                }
-            }
-        } catch (SAXException | IOException e) {
-            throw new MmtcException(String.format("Failed to validate the configuration file against %s,", baseConfigPath), e);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        if (missingKeys.isEmpty()) {
-            logger.info(String.format("All required config keys validated against %s successfully.",baseConfigPath));
-        } else {
-            throw new MmtcException(String.format("Failed to validate TimeCorrelationConfigProperties.xml, missing %d required key(s): %s",missingKeys.size(), missingKeys));
-        }
-    }
-
-    private static final List<String> REQD_SCLK_SCET_CONFIG_KEY_GROUP = Arrays.asList(
-            "product.sclkScetFile.create",
-            "product.sclkScetFile.dir",
-            "product.sclkScetFile.baseName",
-            "product.sclkScetFile.separator",
-            "product.sclkScetFile.suffix",
-            "product.sclkScetFile.datasetId",
-            "product.sclkScetFile.producerId",
-            "product.sclkScetFile.scetUtcPrecision"
-    );
-
-    private static final List<String> REQD_UPLINK_CMD_FILE_CONFIG_KEY_GROUP = Arrays.asList(
-            "product.uplinkCmdFile.create",
-            "product.uplinkCmdFile.outputDir",
-            "product.uplinkCmdFile.baseName"
-    );
-
-    public void validateSclkScetConfiguration() throws MmtcException {
-        List<String> missingKeys = checkForMissingKeysInGroup(REQD_SCLK_SCET_CONFIG_KEY_GROUP);
-
-        if (! missingKeys.isEmpty()) {
-            throw new MmtcException("SCLK-SCET operations require the following keys to be set: " + missingKeys.toString());
-        }
-    }
-
-    public void validateUplinkCmdFileConfiguration() throws MmtcException {
-        List<String> missingKeys = checkForMissingKeysInGroup(REQD_UPLINK_CMD_FILE_CONFIG_KEY_GROUP);
-
-        if (! missingKeys.isEmpty()) {
-            throw new MmtcException("Uplink command file operations require the following keys to be set: " + missingKeys.toString());
-        }
-    }
-
-    public boolean isSclkScetConfigurationComplete() {
-        return checkForMissingKeysInGroup(REQD_SCLK_SCET_CONFIG_KEY_GROUP).isEmpty();
-    }
-
-    public boolean isUplinkFileConfigurationComplete() {
-        return checkForMissingKeysInGroup(REQD_UPLINK_CMD_FILE_CONFIG_KEY_GROUP).isEmpty();
-    }
-
-    private List<String> checkForMissingKeysInGroup(List<String> requiredKeys) {
-        List<String> missingKeys = new ArrayList();
-
-        for (String key : requiredKeys) {
-            if (! timeCorrelationConfig.getConfig().containsKey(key)) {
-                missingKeys.add(key);
-            }
-        }
-
-        return missingKeys;
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/TimeCorrelationConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/TimeCorrelationConfig.java
@@ -2,11 +2,13 @@ package edu.jhuapl.sd.sig.mmtc.cfg;
 
 import org.apache.commons.configuration2.FileBasedConfiguration;
 
+import java.nio.file.Path;
+
 /**
  * Parent class for TimeCorrelationXmlPropertiesConfig.
  */
-abstract class TimeCorrelationConfig extends AbstractConfig {
-    TimeCorrelationConfig(String path) {
+public abstract class TimeCorrelationConfig extends AbstractConfig {
+    TimeCorrelationConfig(Path path) {
         super(path);
     }
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/TimeCorrelationXmlPropertiesConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/TimeCorrelationXmlPropertiesConfig.java
@@ -12,12 +12,16 @@ import org.apache.logging.log4j.Logger;
 import edu.jhuapl.sd.sig.mmtc.util.Environment;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Provides access to the time correlation properties configuration file
  * parameters.
  */
 public class TimeCorrelationXmlPropertiesConfig extends TimeCorrelationConfig {
+    public static final String TIME_COR_CONFIG_PROPERTIES_FILENAME = "TimeCorrelationConfigProperties.xml";
+
     private FileBasedConfigurationBuilder<LocatedXMLPropertiesConfiguration> builder;
 
     private static final Logger logger = LogManager.getLogger();
@@ -34,19 +38,18 @@ public class TimeCorrelationXmlPropertiesConfig extends TimeCorrelationConfig {
      */
     public boolean load() {
         try {
-            final String fileName = "TimeCorrelationConfigProperties.xml";
             String basePath = Environment.getEnvironmentVariable("TK_CONFIG_PATH");
             Parameters params = new Parameters();
 
-            logger.info(String.format("Attempting to load configuration file %s from $TK_CONFIG_PATH (%s).", fileName, basePath));
+            logger.info(String.format("Attempting to load configuration file %s from $TK_CONFIG_PATH (%s).", TIME_COR_CONFIG_PROPERTIES_FILENAME, basePath));
             builder = new FileBasedConfigurationBuilder<>(LocatedXMLPropertiesConfiguration.class)
                     .configure(params.properties()
                     .setBasePath(basePath)
-                    .setFileName(fileName)
+                    .setFileName(TIME_COR_CONFIG_PROPERTIES_FILENAME)
                     .setLocationStrategy(new BasePathLocationStrategy())
                     .setListDelimiterHandler(new DefaultListDelimiterHandler(',')));
 
-            setPath(basePath + File.separator + fileName);
+            setPath(Paths.get(basePath, TIME_COR_CONFIG_PROPERTIES_FILENAME));
 
             final LocatedXMLPropertiesConfiguration config = builder.getConfiguration();
             final boolean success = config != null;
@@ -54,7 +57,7 @@ public class TimeCorrelationXmlPropertiesConfig extends TimeCorrelationConfig {
             if (success) {
                 String urlString = config.getURLString();
                 logger.info("Loaded configuration from: " + urlString);
-                setPath(urlString);
+                setPath(Paths.get(urlString));
             }
 
             return success;

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/TextProduct.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/TextProduct.java
@@ -1,5 +1,6 @@
 package edu.jhuapl.sd.sig.mmtc.products;
 
+import edu.jhuapl.sd.sig.mmtc.app.MmtcCli;
 import edu.jhuapl.sd.sig.mmtc.app.TimeCorrelationApp;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 import org.apache.logging.log4j.LogManager;
@@ -349,7 +350,7 @@ abstract class TextProduct {
             throw new TextProductException("Error creating new Time Correlation file \"" + newFilePath + "\".", e);
         }
 
-        logger.info(TimeCorrelationApp.USER_NOTICE, "Created new time correlation product file: " + newFilePath);
+        logger.info(MmtcCli.USER_NOTICE, "Created new time correlation product file: " + newFilePath);
     }
 
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/UplinkCmdFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/UplinkCmdFile.java
@@ -1,5 +1,6 @@
 package edu.jhuapl.sd.sig.mmtc.products;
 
+import edu.jhuapl.sd.sig.mmtc.app.MmtcCli;
 import edu.jhuapl.sd.sig.mmtc.app.TimeCorrelationApp;
 import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationAppConfig;
 import org.apache.logging.log4j.LogManager;
@@ -37,6 +38,6 @@ public class UplinkCmdFile {
         writer = new BufferedWriter(new FileWriter(filespec));
         writer.write(commandString.toString());
         writer.close();
-        logger.info(TimeCorrelationApp.USER_NOTICE, "Wrote new uplink command file at: " + Paths.get(filespec));
+        logger.info(MmtcCli.USER_NOTICE, "Wrote new uplink command file at: " + Paths.get(filespec));
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/sandbox/MmtcSandboxCreator.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/sandbox/MmtcSandboxCreator.java
@@ -1,0 +1,433 @@
+package edu.jhuapl.sd.sig.mmtc.sandbox;
+
+import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcSandboxCreatorConfig;
+import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationAppConfig;
+import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationXmlPropertiesConfig;
+import edu.jhuapl.sd.sig.mmtc.products.SclkKernel;
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static edu.jhuapl.sd.sig.mmtc.app.MmtcCli.USER_NOTICE;
+
+public class MmtcSandboxCreator {
+    private static final Logger logger = LogManager.getLogger();
+
+    private final MmtcSandboxCreatorConfig config;
+
+    private final Path originalMmtcHomeDir;
+    private final Path originalTkConfigDir;
+    private final MmtcConfig originalTkConfig;
+
+    private final Path sandboxedMmtcHomeDir;
+    private Path sandboxedTkConfDir;
+    private Path sandboxedTkConfigPath;
+    private Document sandboxedTkConfig;
+
+    public MmtcSandboxCreator(String... args) throws Exception {
+        this.config = new MmtcSandboxCreatorConfig(args);
+
+        // the only argument to this command should be the path
+        // check that it exists and is writable
+
+        this.originalMmtcHomeDir = Paths.get(System.getenv("MMTC_HOME"));
+        this.originalTkConfigDir = Paths.get(System.getenv("TK_CONFIG_PATH"));
+        this.originalTkConfig = config; // new TimeCorrelationAppConfig();
+
+        this.sandboxedMmtcHomeDir = config.getNewSandboxPath();
+    }
+
+    public void create() throws Exception {
+        logger.info(USER_NOTICE, String.format("Creating new sandbox at %s", this.sandboxedMmtcHomeDir));
+
+        // Create sandbox directory
+        if (Files.exists(sandboxedMmtcHomeDir)) {
+            throw new MmtcException(String.format("The sandbox target path %s already exists; please remove the directory or file at this path or choose a different location to create your sandbox.", sandboxedMmtcHomeDir));
+        }
+
+        try {
+            Files.createDirectories(sandboxedMmtcHomeDir);
+        } catch (IOException e) {
+            throw new MmtcException("Could not create a sandbox at the given path", e);
+        }
+
+        // Copy MMTC start script, libs, log conf, and docs (if present)
+        copyProgramDirs();
+        copyDocsDir();
+
+        // Create a new copy of MMTC's configuration directory and contents
+        sandboxedTkConfDir = sandboxedMmtcHomeDir.resolve("conf");
+        Files.createDirectory(sandboxedTkConfDir);
+        sandboxedTkConfigPath = sandboxedTkConfDir.resolve(TimeCorrelationXmlPropertiesConfig.TIME_COR_CONFIG_PROPERTIES_FILENAME);
+        Files.copy(
+                originalTkConfigDir.resolve(TimeCorrelationXmlPropertiesConfig.TIME_COR_CONFIG_PROPERTIES_FILENAME),
+                sandboxedTkConfigPath
+        );
+        sandboxedTkConfig = parseXml(sandboxedTkConfigPath);
+
+        copyLoggerConfiguration();
+        copySecondaryConfigurationFiles();
+        copyOutputs();
+
+        // Write new config file
+        writeXml(sandboxedTkConfig, sandboxedTkConfigPath);
+
+        logger.info(USER_NOTICE, "New MMTC sandbox created at: " + sandboxedMmtcHomeDir.toAbsolutePath());
+        logger.info(USER_NOTICE, "Before using, be sure to do one of the following: either unset $MMTC_HOME and $TK_CONFIG_PATH, or set them to reference the new sandbox location, e.g.:");
+        logger.info(USER_NOTICE, "export MMTC_HOME=" + sandboxedMmtcHomeDir.toAbsolutePath());
+        logger.info(USER_NOTICE, "export TK_CONFIG_PATH=" + sandboxedTkConfigPath.toAbsolutePath());
+    }
+
+    private void copyProgramDirs() throws IOException {
+        // copy required static resources for MMTC software
+        for (String reqdSubDir : Arrays.asList("bin", "lib")) {
+            FileUtils.copyDirectory(
+                    originalMmtcHomeDir.resolve(reqdSubDir).toFile(),
+                    sandboxedMmtcHomeDir.resolve(reqdSubDir).toFile()
+            );
+        }
+    }
+
+    private void copyDocsDir() throws IOException {
+        if (Files.exists(originalMmtcHomeDir.resolve("docs"))) {
+            FileUtils.copyDirectory(
+                    originalMmtcHomeDir.resolve("docs").toFile(),
+                    sandboxedMmtcHomeDir.resolve("docs").toFile()
+            );
+        }
+    }
+
+    private void copySecondaryConfigurationFiles() throws IOException {
+        // SCLK partition map
+        {
+            final Path newSclkPartitionMapPath = sandboxedTkConfDir.resolve(originalTkConfig.getSclkPartitionMapPath().getFileName());
+            Files.copy(
+                    originalTkConfig.getSclkPartitionMapPath(),
+                    newSclkPartitionMapPath
+            );
+            setConfigEntryVal(sandboxedTkConfig, "sclkPartitionMap.path", newSclkPartitionMapPath.toString());
+        }
+
+        // Ground Station map
+        {
+            final Path newGroundStationMapPath = sandboxedTkConfDir.resolve(originalTkConfig.getGroundStationMapPath().getFileName());
+            Files.copy(
+                    originalTkConfig.getGroundStationMapPath(),
+                    newGroundStationMapPath
+            );
+            setConfigEntryVal(sandboxedTkConfig, "groundStationMap.path", newGroundStationMapPath.toString());
+        }
+
+        // Telemetry source plugins
+        {
+            // the plugin copying below handles the fact that the plugin directory may already exist from the above copying of the 'lib' directory
+            final Path newTlmSourcePluginDir = Files.createDirectories(sandboxedMmtcHomeDir.resolve(Paths.get("lib", "plugins")));
+            List<Path> pluginJarsToCopy = Files.list(originalTkConfig.getTelemetrySourcePluginDirectory()).filter(p -> p.startsWith(originalTkConfig.getTelemetrySourcePluginJarPrefix())).collect(Collectors.toList());
+            for (Path pluginJar : pluginJarsToCopy) {
+                Files.copy(pluginJar, newTlmSourcePluginDir.resolve(pluginJar.getFileName()), StandardCopyOption.REPLACE_EXISTING);
+            }
+            setConfigEntryVal(sandboxedTkConfig, "telemetry.source.pluginDirectory", newTlmSourcePluginDir.toString());
+
+            Map<String, String> configKeysToUpdate = config.getTelemetrySource().sandboxTelemetrySourceConfiguration(config, sandboxedMmtcHomeDir, sandboxedTkConfDir);
+            for (Map.Entry<String, String> updatedKeyVal : configKeysToUpdate.entrySet()) {
+                final String key = updatedKeyVal.getKey();
+                final String val = updatedKeyVal.getValue();
+
+                if (! key.startsWith("telemetry.source.plugin.")) {
+                    throw new IOException(String.format("Invalid config key update requested by plugin: %s=%s", key, val));
+                }
+
+                setConfigEntryVal(sandboxedTkConfig, key, val);
+            }
+        }
+
+        // Copy the metakernel, if it's specified, as MMTC-specific metakernels should be considered part of MMTC-managed configuration
+        {
+            if (originalTkConfig.containsNonEmptyKey("spice.kernel.mk.path")) {
+                Files.createDirectory(sandboxedMmtcHomeDir.resolve("kernels"));
+
+                Path newMetakernelLocation = sandboxedMmtcHomeDir.resolve(
+                        Paths.get("kernels", Paths.get(originalTkConfig.getString("spice.kernel.mk.path")).getFileName().toString())
+                );
+                Files.copy(
+                        Paths.get(originalTkConfig.getString("spice.kernel.mk.path")),
+                        newMetakernelLocation
+                );
+                setConfigEntryVal(sandboxedTkConfig, "spice.kernel.mk.path", newMetakernelLocation.toString());
+            }
+        }
+
+        // other kernels that are referenced are unlikely to be MMTC-specific, so just update their paths to absolute ones to ensure they can be read from the new sandbox location
+        {
+            // don't need to handle SCLK kernel here; those are read from the output directory
+            // don't need to handle metakernel, as we copied that above
+
+            // there should only be one lsk
+            if (originalTkConfig.containsKey("spice.kernel.lsk.path")) {
+                setConfigEntryVal(
+                        sandboxedTkConfig,
+                        "spice.kernel.lsk.path",
+                        Paths.get(originalTkConfig.getString("spice.kernel.lsk.path")).toAbsolutePath().toString()
+                );
+            }
+
+            // preserving order for kernels is critical, as order is meaningful to the SPICE kernel furnishing process
+            List<String> kernelTypesForPathUpdates = Arrays.asList(
+                    "spk",
+                    "pck",
+                    "fk"
+            );
+
+            for (String kernelType : kernelTypesForPathUpdates) {
+                final String key = String.format("spice.kernel.%s.path", kernelType);
+                String[] kernelArr = originalTkConfig.getStringArray(key);
+
+                String kernelsWithAbsolutePaths = Arrays.stream(kernelArr)
+                            .map(kernel -> Paths.get(kernel).toAbsolutePath().toString())
+                            .collect(Collectors.joining(",\n"));
+
+                setConfigEntryVal(
+                        sandboxedTkConfig,
+                        key,
+                        "\n" + kernelsWithAbsolutePaths
+                );
+            }
+        }
+    }
+
+    private void copyLoggerConfiguration() throws IOException {
+        // create new log directory and set new logs to go there
+        Files.createDirectory(sandboxedMmtcHomeDir.resolve("log"));
+
+        if (Files.exists(originalTkConfigDir.resolve("log4j2.xml"))) {
+            Files.copy(
+                    originalTkConfigDir.resolve("log4j2.xml"),
+                    sandboxedTkConfDir.resolve("log4j2.xml")
+            );
+        } else {
+            logger.info(String.format("Could not locate log4j2.xml; copying default logger configuration to %s.  Please configure as desired.", sandboxedTkConfDir.resolve("log4j2.xml")));
+            Files.copy(
+                MmtcSandboxCreator.class.getResourceAsStream("log4j2.xml"),
+                sandboxedTkConfDir.resolve("log4j2.xml")
+            );
+        }
+    }
+
+    private void copyOutputs() throws IOException {
+        final Path newOutputDir = sandboxedMmtcHomeDir.resolve("output");
+
+        // SCLK kernels
+        {
+            final Path originalSclkOutputDir = originalTkConfig.getSclkKernelOutputDir().toAbsolutePath();
+            final Path newSclkOutputDir;
+            if (originalSclkOutputDir.startsWith(originalMmtcHomeDir)) {
+                newSclkOutputDir = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalSclkOutputDir));
+            } else {
+                newSclkOutputDir = newOutputDir.resolve("sclk");
+            }
+
+            Files.createDirectories(newSclkOutputDir);
+            List<Path> sclkKernelsToCopy = Files.list(originalSclkOutputDir)
+                    .filter(p -> p.getFileName().toString().startsWith(originalTkConfig.getSclkKernelBasename()))
+                    .filter(p -> p.getFileName().toString().endsWith(SclkKernel.FILE_SUFFIX))
+                    .collect(Collectors.toList());
+            for (Path sclkKernel : sclkKernelsToCopy) {
+                Files.copy(
+                        sclkKernel,
+                        newSclkOutputDir.resolve(sclkKernel.getFileName())
+                );
+            }
+            setConfigEntryVal(sandboxedTkConfig, "spice.kernel.sclk.kerneldir", newSclkOutputDir.toString());
+        }
+
+        // Run History file
+        {
+            final Path newRunHistoryFilePath;
+            if (originalTkConfig.getRunHistoryFilePath().startsWith(originalMmtcHomeDir)) {
+                newRunHistoryFilePath = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalTkConfig.getRunHistoryFilePath()));
+            } else {
+                newRunHistoryFilePath = newOutputDir.resolve(originalTkConfig.getRunHistoryFilePath().getFileName());
+            }
+
+            Files.createDirectories(newRunHistoryFilePath.getParent());
+            copyIfExists(
+                    originalTkConfig.getRunHistoryFilePath(),
+                    newRunHistoryFilePath
+            );
+            setConfigEntryVal(sandboxedTkConfig, "table.runHistoryFile.path", newRunHistoryFilePath.toString());
+        }
+
+        // Raw Telemetry Table
+        {
+            final Path newRawTelemetryTablePath;
+            if (originalTkConfig.getRawTelemetryTablePath().startsWith(originalMmtcHomeDir)) {
+                newRawTelemetryTablePath = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalTkConfig.getRawTelemetryTablePath()));
+            } else {
+                newRawTelemetryTablePath = newOutputDir.resolve(originalTkConfig.getRawTelemetryTablePath().getFileName());
+            }
+
+            Files.createDirectories(newRawTelemetryTablePath.getParent());
+            copyIfExists(
+                    originalTkConfig.getRawTelemetryTablePath(),
+                    newRawTelemetryTablePath
+            );
+            setConfigEntryVal(sandboxedTkConfig, "table.rawTelemetryTable.path", newRawTelemetryTablePath.toString());
+        }
+
+        // Time History File
+        {
+            final Path newTimeHistoryFilePath;
+            if (originalTkConfig.getTimeHistoryFilePath().startsWith(originalMmtcHomeDir)) {
+                newTimeHistoryFilePath = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalTkConfig.getTimeHistoryFilePath()));
+            } else {
+                newTimeHistoryFilePath = newOutputDir.resolve(originalTkConfig.getTimeHistoryFilePath().getFileName());
+            }
+
+            Files.createDirectories(newTimeHistoryFilePath.getParent());
+            copyIfExists(
+                    originalTkConfig.getTimeHistoryFilePath(),
+                    newTimeHistoryFilePath
+            );
+            setConfigEntryVal(sandboxedTkConfig, "table.timeHistoryFile.path", newTimeHistoryFilePath.toString());
+        }
+
+        // SCLK-SCET files
+        {
+            // todo change this to see if any sclk-scet files have ever been produced
+            if (originalTkConfig.createSclkScetFile()) {
+                final Path originalSclkScetOutputDir = originalTkConfig.getSclkScetOutputDir().toAbsolutePath();
+                final Path newSclkScetOutputDir;
+                if (originalSclkScetOutputDir.startsWith(originalMmtcHomeDir)) {
+                    newSclkScetOutputDir = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalSclkScetOutputDir));
+                } else {
+                    newSclkScetOutputDir = newOutputDir.resolve("sclkscet");
+                }
+
+                Files.createDirectories(newSclkScetOutputDir);
+                List<Path> sclkScetFilesToCopy = Files.list(originalSclkScetOutputDir)
+                        .filter(p -> p.getFileName().toString().startsWith(originalTkConfig.getSclkScetFileBasename()))
+                        .filter(p -> p.getFileName().toString().endsWith(originalTkConfig.getSclkScetFileSuffix()))
+                        .collect(Collectors.toList());
+                for (Path sclkScetFile : sclkScetFilesToCopy) {
+                    Files.copy(
+                            sclkScetFile,
+                            newSclkScetOutputDir.resolve(sclkScetFile.getFileName())
+                    );
+                }
+                setConfigEntryVal(sandboxedTkConfig, "product.sclkScetFile.dir", newSclkScetOutputDir.toString());
+            }
+        }
+
+        // uplink cmd files
+        {
+            // todo change this to see if any uplink command files have ever been produced
+            if (originalTkConfig.containsKey("product.uplinkCmdFile.outputDir")) {
+                final Path originalUplinkCmdFileOutputDir = Paths.get(originalTkConfig.getUplinkCmdFileDir()).toAbsolutePath();
+                final Path newUplinkCmdFileOutputDir;
+                if (originalUplinkCmdFileOutputDir.startsWith(originalMmtcHomeDir)) {
+                    newUplinkCmdFileOutputDir = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalUplinkCmdFileOutputDir));
+                } else {
+                    newUplinkCmdFileOutputDir = newOutputDir.resolve("uplinkCmd");
+                }
+
+                Files.createDirectories(newUplinkCmdFileOutputDir);
+                List<Path> uplinkCmdFilesToCopy = Files.list(originalUplinkCmdFileOutputDir)
+                        .filter(p -> p.getFileName().toString().startsWith(originalTkConfig.getUplinkCmdFileBasename()))
+                        .collect(Collectors.toList());
+                for (Path uplinkCmdFile : uplinkCmdFilesToCopy) {
+                    Files.copy(
+                            uplinkCmdFile,
+                            newUplinkCmdFileOutputDir.resolve(uplinkCmdFile.getFileName())
+                    );
+                }
+                setConfigEntryVal(sandboxedTkConfig, "product.uplinkCmdFile.outputDir", newUplinkCmdFileOutputDir.toString());
+            }
+        }
+    }
+
+    private static void copyIfExists(final Path source, final Path destination) throws IOException {
+        if (! Files.exists(source)) {
+            return;
+        }
+
+        Files.copy(
+                source,
+                destination
+        );
+    }
+
+    private static void setConfigEntryVal(final Document document, final String key, final String val) {
+        // Select the correct config key and set the value in loaded document
+        NodeList entryNodes = document.getElementsByTagName("entry");
+
+        boolean keyFound = false;
+        for (int i = 0; i < entryNodes.getLength(); i++) {
+            Node entryNode = entryNodes.item(i);
+            if (entryNode.getNodeType() == Node.ELEMENT_NODE) {
+                Element entryElement = (Element) entryNode;
+                String entryKey = entryElement.getAttribute("key");
+                if (entryKey.equals(key)) {
+                    entryElement.setTextContent(val);
+                    keyFound = true;
+                }
+            }
+        }
+
+        if (! keyFound) {
+            Element newEntry = document.createElement("entry");
+            newEntry.setAttribute("key", key);
+            newEntry.setTextContent(val);
+            document.getElementsByTagName("properties").item(0).appendChild(newEntry);
+        }
+    }
+
+    private static Document parseXml(Path path) throws IOException {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setValidating(false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            return factory.newDocumentBuilder().parse(path.toFile());
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new IOException(e);
+        }
+    }
+
+    private static void writeXml(Document document, Path destinationPath) throws IOException {
+        try {
+            StringWriter writer = new StringWriter();
+            TransformerFactory tf = TransformerFactory.newInstance();
+            Transformer transformer = tf.newTransformer();
+            transformer.transform(new DOMSource(document), new StreamResult(writer));
+            DOMSource source = new DOMSource(document);
+            StringWriter strWriter = new StringWriter();
+            StreamResult result = new StreamResult(strWriter);
+            transformer.transform(source, result);
+            Files.write(destinationPath, strWriter.getBuffer().toString().getBytes(StandardCharsets.UTF_8));
+        } catch (TransformerException e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/table/AbstractTimeCorrelationTable.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/table/AbstractTimeCorrelationTable.java
@@ -6,11 +6,8 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.CSVRecord;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.*;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -26,16 +23,16 @@ public abstract class AbstractTimeCorrelationTable {
     CSVParser parser;
 
     /**
-     * Create the table file object from the specified URI.
+     * Create the table file object from the specified path.
      *
-     * @param uri the path to the table
+     * @param path the path to the table
      */
-    AbstractTimeCorrelationTable(URI uri) {
-        setUri(uri);
+    AbstractTimeCorrelationTable(Path path) {
+        setPath(path);
     }
 
-    protected void setUri(URI uri) {
-        file = new File(uri.getPath());
+    protected void setPath(Path path) {
+        file = path.toFile();
     }
 
     protected File getFile() { return this.file; }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/table/RawTelemetryTable.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/table/RawTelemetryTable.java
@@ -1,6 +1,6 @@
 package edu.jhuapl.sd.sig.mmtc.table;
 
-import java.net.URI;
+import java.nio.file.Path;
 import java.util.*;
 
 /**
@@ -25,8 +25,8 @@ public class RawTelemetryTable extends AbstractTimeCorrelationTable {
     public static final String DATA_RATE_BPS = "Data Rate BPS";
     public static final String FRAME_SIZE_BITS = "Frame Size Bits";
 
-    public RawTelemetryTable(URI uri) {
-        super(uri);
+    public RawTelemetryTable(Path path) {
+        super(path);
     }
 
     public List<String> getHeaders() {

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/table/RunHistoryFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/table/RunHistoryFile.java
@@ -2,15 +2,16 @@ package edu.jhuapl.sd.sig.mmtc.table;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
 import edu.jhuapl.sd.sig.mmtc.app.MmtcRollbackException;
-import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationAppConfig;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import org.apache.commons.csv.CSVRecord;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
-import java.util.function.Function;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class RunHistoryFile extends AbstractTimeCorrelationTable {
     public static final RunHistoryOutputProductDefinitions OUTPUT_PRODUCT_DEFINITIONS = new RunHistoryOutputProductDefinitions();
@@ -36,8 +37,8 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
         INCLUDE_ROLLBACKS
     }
 
-    public RunHistoryFile(URI uri) {
-        super(uri);
+    public RunHistoryFile(Path path) {
+        super(path);
     }
 
     @Override
@@ -143,7 +144,7 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
 
     @FunctionalInterface
     public interface ConfiguredOutputProductDefinitionConverter {
-        ConfiguredOutputProductDefinition apply(TimeCorrelationAppConfig conf) throws MmtcException;
+        ConfiguredOutputProductDefinition apply(MmtcConfig conf) throws MmtcException;
     }
 
     public static class OutputProductTypeDefinition {
@@ -212,8 +213,8 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
                             POSTRUN_RAWTLMTABLE,
                             OutputProductTypeDefinition.Type.LINE_APPENDED_CSV,
                             (conf) -> new ConfiguredAppendedCsvOutputProductDefinition(
-                                    Paths.get(conf.getRawTelemetryTableUri().toString().replace("file://", "")),
-                                    new RawTelemetryTable(conf.getRawTelemetryTableUri()
+                                    Paths.get(conf.getRawTelemetryTablePath().toString().replace("file://", "")),
+                                    new RawTelemetryTable(conf.getRawTelemetryTablePath()
                                     )
                             )
                     ),
@@ -223,8 +224,8 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
                             POSTRUN_TIMEHIST,
                             OutputProductTypeDefinition.Type.LINE_APPENDED_CSV,
                             (conf) -> new ConfiguredAppendedCsvOutputProductDefinition(
-                                        Paths.get(conf.getTimeHistoryFileUri().toString().replace("file://", "")),
-                                        new TimeHistoryFile(conf.getTimeHistoryFileUri()
+                                        Paths.get(conf.getTimeHistoryFilePath().toString().replace("file://", "")),
+                                        new TimeHistoryFile(conf.getTimeHistoryFilePath()
                                         )
                             )
                     ),

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/table/TimeHistoryFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/table/TimeHistoryFile.java
@@ -1,6 +1,6 @@
 package edu.jhuapl.sd.sig.mmtc.table;
 
-import java.net.URI;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -104,12 +104,12 @@ public class TimeHistoryFile extends AbstractTimeCorrelationTable {
 
     private final ArrayList<String> columns;
 
-    public TimeHistoryFile(URI uri) {
-        this(uri, Collections.emptyList());
+    public TimeHistoryFile(Path path) {
+        this(path, Collections.emptyList());
     }
 
-    public TimeHistoryFile(URI uri, List<String> columnsToExclude) {
-        super(uri);
+    public TimeHistoryFile(Path path, List<String> columnsToExclude) {
+        super(path);
         this.columns = new ArrayList<>(DEFAULT_COLUMNS);
         this.columns.removeAll(columnsToExclude);
     }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/tlm/TelemetrySource.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/tlm/TelemetrySource.java
@@ -1,12 +1,16 @@
 package edu.jhuapl.sd.sig.mmtc.tlm;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationAppConfig;
 import org.apache.commons.cli.Option;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -49,7 +53,7 @@ public interface TelemetrySource {
      * the telemetry that the TelemetrySource implementation can provide.  If an incompatible filter is enabled, the
      * implementation should throw an MmtcException containing information about the issue.
      * <p>
-     * This method is called once upon MMTC initialization.
+     * This method is called once during an MMTC time correlation invocation, before any correlation processing occurs.
      *
      * @param config the complete TimeCorrelationAppConfig that MMTC will use to run, sourced from a TimeCorrelationConfigProperties.xml file
      * @throws MmtcException if there is an issue configuring the TelemetrySource, or another issue that indicates time correlation should not proceed
@@ -78,6 +82,14 @@ public interface TelemetrySource {
      * @throws MmtcException if there is a problem cleanly disconnecting from the underlying source of telemetry
      */
     void disconnect() throws MmtcException;
+
+    /**
+     * Copy plugin-specific configuration to a sandbox directory and transform .  This is not called between connect/disconnect calls.
+     *
+     * @throws IOException if there is a problem copying the plugin's configuration to the sandbox directory
+     * @return a map of config keys to values to apply to the new sandbox configuration
+     */
+    Map<String, String> sandboxTelemetrySourceConfiguration(MmtcConfig mmtcConfig, Path sandboxRoot, Path sandboxConfigRoot) throws IOException;
 
     /**
      * Query the underlying source of telemetry for all timekeeping telemetry within the given range of time (always given

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/tlm/TimekeepingPacketParser.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/tlm/TimekeepingPacketParser.java
@@ -4,11 +4,10 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 
 import javax.xml.XMLConstants;
@@ -48,7 +47,7 @@ public class TimekeepingPacketParser implements Iterable<TimekeepingRecord> {
      * @throws SAXException if a SAX exception occurred while parsing the TK packet description file
      * @throws MalformedURLException if the TK packet description file could not be accessed
      */
-    public TimekeepingPacketParser(URI packetDefinitionFile) throws JAXBException, SAXException, MalformedURLException, IllegalStateException {
+    public TimekeepingPacketParser(Path packetDefinitionFile) throws JAXBException, SAXException, MalformedURLException, IllegalStateException {
         logger.trace("TimekeepingPacketParser: Instantiating XML parser");
         try {
             unmarshaller = JAXBContext.newInstance(PacketDefinition.class).createUnmarshaller();
@@ -64,15 +63,9 @@ public class TimekeepingPacketParser implements Iterable<TimekeepingRecord> {
         }
 
         logger.trace("TimekeepingPacketParser: parsing XML packet definition [" + packetDefinitionFile + "]");
-        URL url;
+
         try {
-            url = new URL(packetDefinitionFile.toString()); // NOTE: we use this because at least when the URI scheme/protocol is missing, the exception message is more useful than URI.toURl()
-        } catch (IllegalArgumentException | MalformedURLException e) {
-            logger.error("Error locating XML packet definition file. Configuration value [" + packetDefinitionFile + "] is not a valid URL and cannot be converted to one.", e);
-            throw e;
-        }
-        try {
-            packetDefinition = (PacketDefinition) unmarshaller.unmarshal(url);
+            packetDefinition = (PacketDefinition) unmarshaller.unmarshal(packetDefinitionFile.toFile());
             if (isValidPacketDef(packetDefinition)) {
                 logger.trace("Packet definition validated successfully");
             }
@@ -96,7 +89,7 @@ public class TimekeepingPacketParser implements Iterable<TimekeepingRecord> {
      * @throws JAXBException if a JAXB exception occurred while parsing the TK packet description file
      * @throws SAXException if a SAX exception occurred while parsing the TK packet description file
      */
-    public TimekeepingPacketParser(URI packetDefinitionFile, URI packetFile) throws IOException, JAXBException, SAXException {
+    public TimekeepingPacketParser(Path packetDefinitionFile, URI packetFile) throws IOException, JAXBException, SAXException {
         this(packetDefinitionFile);
         packets = Files.readAllBytes(new File(packetFile).toPath());
     }
@@ -111,7 +104,7 @@ public class TimekeepingPacketParser implements Iterable<TimekeepingRecord> {
      * @throws SAXException if a SAX exception occurred while parsing the TK packet description file
      * @throws MalformedURLException if the TK packet description file could not be accessed
      */
-    public TimekeepingPacketParser(URI packetDefinitionFile, byte[] packets)
+    public TimekeepingPacketParser(Path packetDefinitionFile, byte[] packets)
             throws MalformedURLException, JAXBException, SAXException {
         this(packetDefinitionFile);
         this.packets = packets;

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/tlm/selection/SamplingTelemetrySelectionStrategy.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/tlm/selection/SamplingTelemetrySelectionStrategy.java
@@ -13,7 +13,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static edu.jhuapl.sd.sig.mmtc.app.TimeCorrelationApp.USER_NOTICE;
+import static edu.jhuapl.sd.sig.mmtc.app.MmtcCli.USER_NOTICE;
 
 public class SamplingTelemetrySelectionStrategy extends TelemetrySelectionStrategy {
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/tlm/selection/WindowingTelemetrySelectionStrategy.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/tlm/selection/WindowingTelemetrySelectionStrategy.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.List;
 
-import static edu.jhuapl.sd.sig.mmtc.app.TimeCorrelationApp.USER_NOTICE;
+import static edu.jhuapl.sd.sig.mmtc.app.MmtcCli.USER_NOTICE;
 
 public class WindowingTelemetrySelectionStrategy extends TelemetrySelectionStrategy {
     private static final Logger logger = LogManager.getLogger();

--- a/mmtc-core/src/main/resources/TimeCorrelationConfigProperties-base.xml
+++ b/mmtc-core/src/main/resources/TimeCorrelationConfigProperties-base.xml
@@ -41,10 +41,10 @@
     <entry key="filter.consecutiveMasterChannelFrames.enabled"/>
 
     <entry key="filter.vcid.enabled"/>
-    <entry key="table.runHistoryFile.uri"/>
-    <entry key="table.rawTelemetryTable.uri"/>
+    <entry key="table.runHistoryFile.path"/>
+    <entry key="table.rawTelemetryTable.path"/>
     <entry key="table.rawTelemetryTable.dateTimePattern"/>
-    <entry key="table.timeHistoryFile.uri"/>
+    <entry key="table.timeHistoryFile.path"/>
     <entry key="table.timeHistoryFile.scetUtcPrecision"/>
 
     <entry key="product.sclkScetFile.create"/>

--- a/mmtc-core/src/main/resources/TimeCorrelationConfigProperties.xsd
+++ b/mmtc-core/src/main/resources/TimeCorrelationConfigProperties.xsd
@@ -127,10 +127,10 @@
       <xs:enumeration value="filter.consecutiveMasterChannelFrames.enabled" />
 
       <!-- File locations -->
-      <xs:enumeration value="table.runHistoryFile.uri"/>
-      <xs:enumeration value="table.rawTelemetryTable.uri"/>
+      <xs:enumeration value="table.runHistoryFile.path"/>
+      <xs:enumeration value="table.rawTelemetryTable.path"/>
       <xs:enumeration value="table.rawTelemetryTable.dateTimePattern"/>
-      <xs:enumeration value="table.timeHistoryFile.uri"/>
+      <xs:enumeration value="table.timeHistoryFile.path"/>
       <xs:enumeration value="table.timeHistoryFile.excludeColumns"/>
       <xs:enumeration value="table.timeHistoryFile.scetUtcPrecision"/>
       <xs:enumeration value="product.sclkScetFile.create"/>

--- a/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/cfg/CorrelationCommandLineConfigTests.java
+++ b/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/cfg/CorrelationCommandLineConfigTests.java
@@ -8,8 +8,8 @@ import java.time.format.DateTimeParseException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class CommandLineConfigTests {
-    private CommandLineConfig config;
+class CorrelationCommandLineConfigTests {
+    private CorrelationCommandLineConfig config;
 
     @Test
     @DisplayName("CommandLineConfig.formDateTime Test 1")
@@ -18,7 +18,7 @@ class CommandLineConfigTests {
         String args[] = new String[2];
         args[0] = "2019-183T02:14:00.0";
         args[1] = "2019-183T04:016:00.0";
-        CommandLineConfig config = new CommandLineConfig(args);
+        CorrelationCommandLineConfig config = new CorrelationCommandLineConfig(args);
 
         String datetimeStr1 = "2019-183T02:14:00.0";
         OffsetDateTime dateTime1 = config.formDateTime(datetimeStr1);

--- a/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/table/RawTelemetryTableTelemetrySourceTests.java
+++ b/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/table/RawTelemetryTableTelemetrySourceTests.java
@@ -23,7 +23,7 @@ public class RawTelemetryTableTelemetrySourceTests {
 
     void loadConfigAndTlmSource(String[] args, String rawTlmTablePath) throws Exception {
         config = spy(new TimeCorrelationAppConfig(args));
-        when(config.getString("telemetry.source.plugin.rawTlmTable.tableFile.uri")).thenReturn(rawTlmTablePath);
+        when(config.getString("telemetry.source.plugin.rawTlmTable.tableFile.path")).thenReturn(rawTlmTablePath);
 
         try {
             tableTlmSource = new RawTelemetryTableTelemetrySource();
@@ -119,7 +119,7 @@ public class RawTelemetryTableTelemetrySourceTests {
         Map<String, TimeCorrelationFilter> enabledFilters = new HashMap<>();
         enabledFilters.put(TimeCorrelationAppConfig.VALID_FILTER, new ValidFilter());
         when(mockedConfig.getFilters()).thenReturn(enabledFilters);
-        when(mockedConfig.getString("telemetry.source.plugin.rawTlmTable.tableFile.uri")).thenReturn("src/test/resources/tables/RawTelemetryTable_empty.csv");
+        when(mockedConfig.getString("telemetry.source.plugin.rawTlmTable.tableFile.path")).thenReturn("src/test/resources/tables/RawTelemetryTable_empty.csv");
 
         RawTelemetryTableTelemetrySource tlmArchive = new RawTelemetryTableTelemetrySource();
 

--- a/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/table/RawTelemetryTableTests.java
+++ b/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/table/RawTelemetryTableTests.java
@@ -5,6 +5,7 @@ import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationAppConfig;
 import org.junit.jupiter.api.*;
 
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,7 +16,7 @@ class RawTelemetryTableTests {
     private RawTelemetryTable table;
 
     void loadTable(String path) throws Exception {
-        table = new RawTelemetryTable(new URI(path));
+        table = new RawTelemetryTable(Paths.get(path));
         table.resetParser();
     }
 

--- a/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/table/RunHistoryFileTests.java
+++ b/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/table/RunHistoryFileTests.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,7 +16,7 @@ public class RunHistoryFileTests {
     @Test
     public void testRunHistoryFileBasicRead() throws URISyntaxException, MmtcException {
         // with no rollbacks, with every column at least partially populated
-        final RunHistoryFile runHistoryFile = new RunHistoryFile(new URI("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh.csv"));
+        final RunHistoryFile runHistoryFile = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh.csv"));
         assertEquals(4, runHistoryFile.readRecords(RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS).size());
         assertEquals(4, runHistoryFile.readRecords(RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS).size());
 
@@ -27,7 +28,7 @@ public class RunHistoryFileTests {
         assertEquals("1734040773", lastRec.getValue(RunHistoryFile.POSTRUN_UPLINKCMD));
 
         // with no rollbacks, with the uplink cmd file columns not populated
-        final RunHistoryFile runHistoryFileNoUplink = new RunHistoryFile(new URI("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-no-uplink.csv"));
+        final RunHistoryFile runHistoryFileNoUplink = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-no-uplink.csv"));
         assertEquals(4, runHistoryFileNoUplink.readRecords(RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS).size());
         assertEquals(4, runHistoryFileNoUplink.readRecords(RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS).size());
 
@@ -39,7 +40,7 @@ public class RunHistoryFileTests {
         assertEquals("-", lastRec.getValue(RunHistoryFile.POSTRUN_UPLINKCMD));
 
         // with a rollback
-        final RunHistoryFile runHistoryFileRollback = new RunHistoryFile(new URI("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-rollback.csv"));
+        final RunHistoryFile runHistoryFileRollback = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-rollback.csv"));
         assertEquals(6, runHistoryFileRollback.readRecords(RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS).size());
         assertEquals(4, runHistoryFileRollback.readRecords(RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS).size());
 
@@ -54,26 +55,22 @@ public class RunHistoryFileTests {
     @Test
     public void testRunHistoryFileValueQueries() throws URISyntaxException, MmtcException {
         // with no rollbacks, with every column at least partially populated
-        final RunHistoryFile runHistoryFile = new RunHistoryFile(new URI("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh.csv"));
+        final RunHistoryFile runHistoryFile = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh.csv"));
         assertEquals(Optional.of("1734040773"), runHistoryFile.getLatestNonEmptyValueOfCol(RunHistoryFile.POSTRUN_UPLINKCMD, RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS));
         assertTrue(runHistoryFile.anyValuesInColumn(RunHistoryFile.POSTRUN_UPLINKCMD));
         assertEquals(Optional.of("1002"), runHistoryFile.getValueOfColForRun("00002", RunHistoryFile.POSTRUN_SCLK));
         assertEquals(Optional.of("1004"), runHistoryFile.getLatestNonEmptyValueOfCol(RunHistoryFile.POSTRUN_SCLK, RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS));
 
         // with no rollbacks, with the uplink cmd file columns not populated
-        final RunHistoryFile runHistoryFileNoUplink = new RunHistoryFile(new URI("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-no-uplink.csv"));
+        final RunHistoryFile runHistoryFileNoUplink = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-no-uplink.csv"));
         assertEquals(Optional.empty(), runHistoryFileNoUplink.getLatestNonEmptyValueOfCol(RunHistoryFile.POSTRUN_UPLINKCMD, RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS));
         assertEquals(Optional.empty(), runHistoryFileNoUplink.getLatestValueOfCol(RunHistoryFile.POSTRUN_UPLINKCMD, RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS));
         assertFalse(runHistoryFileNoUplink.anyValuesInColumn(RunHistoryFile.POSTRUN_UPLINKCMD));
 
         // with a rollback
-        final RunHistoryFile runHistoryFileRollback = new RunHistoryFile(new URI("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-rollback.csv"));
+        final RunHistoryFile runHistoryFileRollback = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-rollback.csv"));
         assertEquals(Optional.of("1753199537"), runHistoryFileRollback.getLatestNonEmptyValueOfCol(RunHistoryFile.POSTRUN_UPLINKCMD, RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS));
         assertEquals(Optional.of("1753199537"), runHistoryFileRollback.getLatestValueOfCol(RunHistoryFile.POSTRUN_UPLINKCMD, RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS));
         assertTrue(runHistoryFileRollback.anyValuesInColumn(RunHistoryFile.POSTRUN_UPLINKCMD));
-
-
     }
-
-
 }

--- a/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/table/TimeHistoryFileTests.java
+++ b/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/table/TimeHistoryFileTests.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,11 +17,10 @@ class TimeHistoryFileTests {
 
     void loadTable(String path) {
         try {
-            URI uri = new URI(path);
-            table = new TimeHistoryFile(uri);
+            table = new TimeHistoryFile(Paths.get(path));
             table.resetParser();
         }
-        catch (URISyntaxException | MmtcException ex) {
+        catch (MmtcException ex) {
             fail("Failed to load TimeHistoryFile file." + ex);
         }
     }

--- a/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/tlm/TimekeepingPacketPostInitializeTests.java
+++ b/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/tlm/TimekeepingPacketPostInitializeTests.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -101,11 +102,10 @@ public class TimekeepingPacketPostInitializeTests {
     }
 
     @BeforeAll
-    public static void instantiateParser()
-            throws MalformedURLException, JAXBException, SAXException, URISyntaxException {
-        //NOTE TimekeepingPacketParser is supposed to be reusable.
-        //We test that by instantiating it only once and sharing it among tests.
-        parser = new TimekeepingPacketParser(TimekeepingPacketPostInitializeTests.class.getResource("/TkPacketTests/PacketDefs/generic_tk_pkt_float_downlink.xml").toURI());
+    public static void instantiateParser() throws MalformedURLException, JAXBException, SAXException {
+        // NOTE TimekeepingPacketParser is designed to be reusable.
+        // We test that by instantiating it only once and sharing it among tests.
+        parser = new TimekeepingPacketParser(Paths.get("src/test/resources/TkPacketTests/PacketDefs/generic_tk_pkt_float_downlink.xml"));
     }
 
     /**

--- a/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/tlm/TimekeepingPacketTests.java
+++ b/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/tlm/TimekeepingPacketTests.java
@@ -3,6 +3,7 @@ package edu.jhuapl.sd.sig.mmtc.tlm;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -194,22 +195,22 @@ public class TimekeepingPacketTests {
     @BeforeAll
     public static void instantiateParser()
             throws JAXBException, SAXException, URISyntaxException, IOException {
-        nullParser = new TimekeepingPacketParser(TimekeepingPacketTests.class.getResource("/TkPacketTests/PacketDefs/generic_tk_pkt_uint_downlink.xml").toURI(), (byte[])null);
-        emptyParser = new TimekeepingPacketParser(TimekeepingPacketTests.class.getResource("/TkPacketTests/PacketDefs/generic_tk_pkt_uint_downlink.xml").toURI(), new byte[] {});
-        arrayParser = new TimekeepingPacketParser(TimekeepingPacketTests.class.getResource("/TkPacketTests/PacketDefs/generic_tk_pkt_uint_downlink.xml").toURI(), packet1);
+        nullParser = new TimekeepingPacketParser(Paths.get("src/test/resources/TkPacketTests/PacketDefs/generic_tk_pkt_uint_downlink.xml"), (byte[])null);
+        emptyParser = new TimekeepingPacketParser(Paths.get("src/test/resources/TkPacketTests/PacketDefs/generic_tk_pkt_uint_downlink.xml"), new byte[] {});
+        arrayParser = new TimekeepingPacketParser(Paths.get("src/test/resources/TkPacketTests/PacketDefs/generic_tk_pkt_uint_downlink.xml"), packet1);
         fileParser = new TimekeepingPacketParser(
-                TimekeepingPacketTests.class.getResource("/TkPacketTests/PacketDefs/generic_tk_pkt_uint_downlink.xml").toURI(),
+                Paths.get("src/test/resources/TkPacketTests/PacketDefs/generic_tk_pkt_uint_downlink.xml"),
                 TimekeepingPacketTests.class.getResource("/TkPacketTests/tkpacket_uintDownlink.dat").toURI());
-        multipacketArrayParser = new TimekeepingPacketParser(TimekeepingPacketTests.class.getResource("/TkPacketTests/PacketDefs/generic_tk_pkt_float_downlink.xml").toURI(), packet2);
-        multipacketArrayWithBadLengthParser = new TimekeepingPacketParser(TimekeepingPacketTests.class.getResource("/TkPacketTests/PacketDefs/generic_tk_pkt_float_downlink.xml").toURI(), packet3);
+        multipacketArrayParser = new TimekeepingPacketParser(Paths.get("src/test/resources/TkPacketTests/PacketDefs/generic_tk_pkt_float_downlink.xml"), packet2);
+        multipacketArrayWithBadLengthParser = new TimekeepingPacketParser(Paths.get("src/test/resources/TkPacketTests/PacketDefs/generic_tk_pkt_float_downlink.xml"), packet3);
         multipacketFileParser = new TimekeepingPacketParser(
-                TimekeepingPacketTests.class.getResource("/TkPacketTests/PacketDefs/generic_tk_pkt_float_downlink.xml").toURI(),
+                Paths.get("src/test/resources/TkPacketTests/PacketDefs/generic_tk_pkt_float_downlink.xml"),
                 TimekeepingPacketTests.class.getResource("/TkPacketTests/tkpacket_2_floatDownlinks.dat").toURI());
         floatDownlinkPacketParser = new TimekeepingPacketParser(
-                TimekeepingPacketTests.class.getResource("/TkPacketTests/PacketDefs/generic_tk_pkt_float_downlink.xml").toURI(),
+                Paths.get("src/test/resources/TkPacketTests/PacketDefs/generic_tk_pkt_float_downlink.xml"),
                 TimekeepingPacketTests.class.getResource("/TkPacketTests/tkpacket_floatDownlink.dat").toURI());
         doubleDownlinkPacketParser = new TimekeepingPacketParser(
-                TimekeepingPacketTests.class.getResource("/TkPacketTests/PacketDefs/generic_tk_pkt_double_downlink.xml").toURI(), packet4);
+                Paths.get("src/test/resources/TkPacketTests/PacketDefs/generic_tk_pkt_double_downlink.xml"), packet4);
     }
 
 
@@ -335,14 +336,14 @@ public class TimekeepingPacketTests {
     public void testHandlingExcessivelyLongField() throws URISyntaxException, MalformedURLException, JAXBException, SAXException {
         AtomicReference<TimekeepingPacketParser> parser = null;
         assertThrows(IllegalStateException.class, () -> { parser.set(new TimekeepingPacketParser(
-                TimekeepingPacketTests.class.getResource("/TkPacketTests/PacketDefs/generic_tk_pkt_incorrect_downlink_size.xml").toURI(), packet4)); });
+                Paths.get("src/test/resources/TkPacketTests/PacketDefs/generic_tk_pkt_incorrect_downlink_size.xml"), packet4)); });
 
     }
 
     @Test
     public void parseMultipacketArrayWithUints() throws URISyntaxException, MalformedURLException, JAXBException, SAXException {
         TimekeepingPacketParser parser = new TimekeepingPacketParser(
-                TimekeepingPacketTests.class.getResource("/TkPacketTests/PacketDefs/generic_tk_pkt_uint_downlink.xml").toURI(), packet5);
+                Paths.get("src/test/resources/TkPacketTests/PacketDefs/generic_tk_pkt_uint_downlink.xml"), packet5);
         Iterator<TimekeepingRecord> packets = parser.iterator();
         packet6Tests(packets);
     }

--- a/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/tlm/selection/BaseTelemetrySelectionStrategyTest.java
+++ b/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/tlm/selection/BaseTelemetrySelectionStrategyTest.java
@@ -45,7 +45,7 @@ public abstract class BaseTelemetrySelectionStrategyTest {
     protected static TelemetrySource getSpiedRawTelemetrySourceFor(TimeCorrelationAppConfig config, String path) throws Exception {
         RawTelemetryTableTelemetrySource rawTlmTable = new RawTelemetryTableTelemetrySource();
         TimeCorrelationAppConfig spiedConfig = Mockito.spy(config);
-        when(spiedConfig.getString("telemetry.source.plugin.rawTlmTable.tableFile.uri")).thenReturn(path);
+        when(spiedConfig.getString("telemetry.source.plugin.rawTlmTable.tableFile.path")).thenReturn(path);
         rawTlmTable.applyConfiguration(spiedConfig);
         return Mockito.spy(rawTlmTable);
     }

--- a/mmtc-core/src/test/resources/ConfigTests/consecutiveCommas/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/ConfigTests/consecutiveCommas/TimeCorrelationConfigProperties.xml
@@ -27,7 +27,7 @@
   <entry key="telemetry.source.name">rawTlmTable</entry>
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
   <entry key="telemetry.tkOscTempWindowSec">60</entry>
@@ -91,9 +91,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///absolute/path/to/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/absolute/path/to/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///absolute/path/to/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/absolute/path/to/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/ConfigTests/minimalKeys/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/ConfigTests/minimalKeys/TimeCorrelationConfigProperties.xml
@@ -34,7 +34,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">false</entry>
 
   <entry key="spice.naifSpacecraftId">-98</entry>
@@ -92,11 +92,10 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.runHistoryFile.uri">file:///opt/local/mmtc/output/RunHistoryFile.csv</entry>
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.runHistoryFile.path">/opt/local/mmtc/output/RunHistoryFile.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-  <entry key="table.summaryTable.uri">file:///opt/local/mmtc/output/SummaryTable.csv</entry>
-  <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/ConfigTests/missingKeys/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/ConfigTests/missingKeys/TimeCorrelationConfigProperties.xml
@@ -37,13 +37,13 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
   <!-- General options for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.chillTimeoutSec">300</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apid">123</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketSizeBytes">29</entry>
-  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri">file:///opt/local/mmtc/conf/tk_packet.xml</entry>
+  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path">/opt/local/mmtc/conf/tk_packet.xml</entry>
 
   <!-- Timekeeping packet metadata column header names for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apidFieldName">apid</entry>
@@ -123,10 +123,10 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.runHistoryFile.uri">file:///opt/local/mmtc/output/RunHistoryFile.csv</entry>
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.runHistoryFile.path">/opt/local/mmtc/output/RunHistoryFile.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/ConfigTests/missingSclkScetKey/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/ConfigTests/missingSclkScetKey/TimeCorrelationConfigProperties.xml
@@ -34,7 +34,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">false</entry>
 
   <entry key="spice.naifSpacecraftId">-98</entry>
@@ -92,11 +92,10 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.runHistoryFile.uri">file:///opt/local/mmtc/output/RunHistoryFile.csv</entry>
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.runHistoryFile.path">/opt/local/mmtc/output/RunHistoryFile.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-  <entry key="table.summaryTable.uri">file:///opt/local/mmtc/output/SummaryTable.csv</entry>
-  <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/ConfigTests/missingUplinkCmdFileKey/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/ConfigTests/missingUplinkCmdFileKey/TimeCorrelationConfigProperties.xml
@@ -34,7 +34,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">false</entry>
 
   <entry key="spice.naifSpacecraftId">-98</entry>
@@ -92,11 +92,10 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.runHistoryFile.uri">file:///opt/local/mmtc/output/RunHistoryFile.csv</entry>
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.runHistoryFile.path">/opt/local/mmtc/output/RunHistoryFile.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-  <entry key="table.summaryTable.uri">file:///opt/local/mmtc/output/SummaryTable.csv</entry>
-  <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/ConfigTests/noSclkModulusOverride/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/ConfigTests/noSclkModulusOverride/TimeCorrelationConfigProperties.xml
@@ -30,7 +30,7 @@
     <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
     <!-- Options for built-in Raw TLM Table telemetry source -->
-    <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+    <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
     <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
     <entry key="telemetry.tkOscTempWindowSec">60</entry>
@@ -94,9 +94,10 @@
     <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
     <!-- Output Files -->
-    <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+    <entry key="table.runHistoryFile.path">/opt/local/mmtc/output/RunHistoryFile.csv</entry>
+    <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
     <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+    <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
     <entry key="table.timeHistoryFile.excludeColumns"></entry>
     <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/ConfigTests/noTkOscTempOrParmWindow/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/ConfigTests/noTkOscTempOrParmWindow/TimeCorrelationConfigProperties.xml
@@ -34,7 +34,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">false</entry>
 
   <entry key="spice.naifSpacecraftId">-98</entry>
@@ -92,10 +92,10 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.runHistoryFile.uri">/opt/local/mmtc/output/RunHistoryFile.csv</entry>
-  <entry key="table.rawTelemetryTable.uri">/opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.runHistoryFile.path">/opt/local/mmtc/output/RunHistoryFile.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-  <entry key="table.timeHistoryFile.uri">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/ConfigTests/trailingCommas/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/ConfigTests/trailingCommas/TimeCorrelationConfigProperties.xml
@@ -27,7 +27,7 @@
   <entry key="telemetry.source.name">rawTlmTable</entry>
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
   <entry key="telemetry.tkOscTempWindowSec">60</entry>
@@ -91,9 +91,10 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///absolute/path/to/output/RawTlmTable.csv</entry>
+  <entry key="table.runHistoryFile.path">/opt/local/mmtc/output/RunHistoryFile.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/absolute/path/to/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///absolute/path/to/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/absolute/path/to/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/ConfigTests/unusualSclkModulusOverride/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/ConfigTests/unusualSclkModulusOverride/TimeCorrelationConfigProperties.xml
@@ -32,7 +32,7 @@
     <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
     <!-- Options for built-in Raw TLM Table telemetry source -->
-    <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+    <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
     <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
     <entry key="telemetry.tkOscTempWindowSec">60</entry>
@@ -96,9 +96,10 @@
     <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
     <!-- Output Files -->
-    <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+    <entry key="table.runHistoryFile.path">/opt/local/mmtc/output/RunHistoryFile.csv</entry>
+    <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
     <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-        <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+    <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
     <entry key="table.timeHistoryFile.excludeColumns"></entry>
     <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/FilterTests/ConsecutiveFrameFilterTest/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/FilterTests/ConsecutiveFrameFilterTest/TimeCorrelationConfigProperties.xml
@@ -33,7 +33,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
   <entry key="telemetry.tkOscTempWindowSec">60</entry>
 
@@ -97,9 +97,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/FilterTests/ConsecutiveMasterChannelFrameFilterTest/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/FilterTests/ConsecutiveMasterChannelFrameFilterTest/TimeCorrelationConfigProperties.xml
@@ -33,7 +33,7 @@
     <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
     <!-- Options for built-in Raw TLM Table telemetry source -->
-    <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+    <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
 
 
@@ -99,9 +99,9 @@
     <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
     <!-- Output Files -->
-    <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+    <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
     <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-        <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+    <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
     <entry key="table.timeHistoryFile.excludeColumns"></entry>
     <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/FilterTests/ConsecutiveMasterChannelFrameFilterTestWithLargerSupplementalSampleOffset/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/FilterTests/ConsecutiveMasterChannelFrameFilterTestWithLargerSupplementalSampleOffset/TimeCorrelationConfigProperties.xml
@@ -33,7 +33,7 @@
     <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
     <!-- Options for built-in Raw TLM Table telemetry source -->
-    <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+    <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
 
 
@@ -99,9 +99,9 @@
     <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
     <!-- Output Files -->
-    <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+    <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
     <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-        <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+    <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
     <entry key="table.timeHistoryFile.excludeColumns"></entry>
     <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/FilterTests/ConsecutiveMasterChannelFrameFilterTestWithZeroMaxMcfc/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/FilterTests/ConsecutiveMasterChannelFrameFilterTestWithZeroMaxMcfc/TimeCorrelationConfigProperties.xml
@@ -33,7 +33,7 @@
     <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
     <!-- Options for built-in Raw TLM Table telemetry source -->
-    <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+    <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
 
 
@@ -99,9 +99,9 @@
     <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
     <!-- Output Files -->
-    <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+    <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
     <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-        <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+    <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
     <entry key="table.timeHistoryFile.excludeColumns"></entry>
     <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/FilterTests/DataRateFilterTest/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/FilterTests/DataRateFilterTest/TimeCorrelationConfigProperties.xml
@@ -34,7 +34,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
 
 
@@ -100,9 +100,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/FilterTests/ErtFilterTest/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/FilterTests/ErtFilterTest/TimeCorrelationConfigProperties.xml
@@ -32,7 +32,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
 
 
@@ -98,9 +98,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/FilterTests/SclkFilterSubsecondTest/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/FilterTests/SclkFilterSubsecondTest/TimeCorrelationConfigProperties.xml
@@ -32,7 +32,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
 
 
@@ -98,9 +98,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/FilterTests/SclkFilterTest/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/FilterTests/SclkFilterTest/TimeCorrelationConfigProperties.xml
@@ -32,7 +32,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
 
 
@@ -98,9 +98,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/FilterTests/VcidFilterTest/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/FilterTests/VcidFilterTest/TimeCorrelationConfigProperties.xml
@@ -32,7 +32,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
 
 
@@ -98,9 +98,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/TelemetrySelection/Sampling/width-12h-rate-12h/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/TelemetrySelection/Sampling/width-12h-rate-12h/TimeCorrelationConfigProperties.xml
@@ -36,7 +36,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
 
@@ -104,9 +104,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/TelemetrySelection/Sampling/width-12h-rate-48h-OnlyStation55/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/TelemetrySelection/Sampling/width-12h-rate-48h-OnlyStation55/TimeCorrelationConfigProperties.xml
@@ -36,7 +36,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
 
@@ -104,9 +104,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/TelemetrySelection/Sampling/width-12h-rate-48h/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/TelemetrySelection/Sampling/width-12h-rate-48h/TimeCorrelationConfigProperties.xml
@@ -36,7 +36,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
 
@@ -104,9 +104,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/TelemetrySelection/Sampling/width-12h-rate-6h/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/TelemetrySelection/Sampling/width-12h-rate-6h/TimeCorrelationConfigProperties.xml
@@ -36,7 +36,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
 
@@ -104,9 +104,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/TelemetrySelection/SeparateConsecutiveWindowing/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/TelemetrySelection/SeparateConsecutiveWindowing/TimeCorrelationConfigProperties.xml
@@ -34,7 +34,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
 
@@ -102,9 +102,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/TelemetrySelection/SeparateConsecutiveWindowingOnlyStation55/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/TelemetrySelection/SeparateConsecutiveWindowingOnlyStation55/TimeCorrelationConfigProperties.xml
@@ -34,7 +34,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
 
@@ -102,9 +102,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/TelemetrySelection/SlidingWindowing/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/TelemetrySelection/SlidingWindowing/TimeCorrelationConfigProperties.xml
@@ -34,7 +34,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
 
@@ -102,9 +102,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/TelemetrySelection/SlidingWindowingOnlyStation55/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/TelemetrySelection/SlidingWindowingOnlyStation55/TimeCorrelationConfigProperties.xml
@@ -34,7 +34,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
 
@@ -102,9 +102,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/TimeCorrelationConfigProperties.xml
@@ -34,7 +34,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">false</entry>
 
   <entry key="telemetry.tkOscTempWindowSec">60</entry>
@@ -98,10 +98,10 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.runHistoryFile.uri">file:///opt/local/mmtc/output/RunHistoryFile.csv</entry>
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.runHistoryFile.path">/opt/local/mmtc/output/RunHistoryFile.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/demo/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/demo/TimeCorrelationConfigProperties.xml
@@ -33,7 +33,7 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///opt/local/mmtc/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/opt/local/mmtc/RawTelemetryTable_NH_reformatted.csv</entry>
   <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
   <entry key="telemetry.tkOscTempWindowSec">60</entry>
@@ -97,10 +97,10 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.runHistoryFile.uri">file:///opt/local/mmtc/output/RunHistoryFile.csv</entry>
-  <entry key="table.rawTelemetryTable.uri">file:///opt/local/mmtc/output/RawTlmTable.csv</entry>
+  <entry key="table.runHistoryFile.path">/opt/local/mmtc/output/RunHistoryFile.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/opt/local/mmtc/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///opt/local/mmtc/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/opt/local/mmtc/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-core/src/test/resources/examples/TimeCorrelationConfigProperties-all.xml
+++ b/mmtc-core/src/test/resources/examples/TimeCorrelationConfigProperties-all.xml
@@ -34,7 +34,7 @@
     <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
     <!-- Options for built-in Raw TLM Table telemetry source -->
-    <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri"></entry>
+    <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path"></entry>
     <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate"></entry>
 
     <entry key="telemetry.tkOscTempWindowSec"></entry>
@@ -82,10 +82,10 @@
     <entry key="filter.dataRate.maxDataRateBps"></entry>
 
     <!-- Output Files -->
-    <entry key="table.runHistoryFile.uri"></entry>
-    <entry key="table.rawTelemetryTable.uri"></entry>
+    <entry key="table.runHistoryFile.path"></entry>
+    <entry key="table.rawTelemetryTable.path"></entry>
     <entry key="table.rawTelemetryTable.dateTimePattern"></entry>
-        <entry key="table.timeHistoryFile.uri"></entry>
+    <entry key="table.timeHistoryFile.path"></entry>
     <entry key="table.timeHistoryFile.excludeColumns"></entry>
     <entry key="table.timeHistoryFile.scetUtcPrecision"></entry>
 
@@ -107,7 +107,7 @@
 
     <!-- timekeeping packet configuration -->
     <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketSizeBytes"></entry>
-    <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri"></entry>
+    <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path"></entry>
     <entry key="telemetry.source.plugin.ampcs.tkpacket.apid"></entry>
     <entry key="telemetry.source.plugin.ampcs.tkpacket.apidFieldName"></entry>
     <entry key="telemetry.source.plugin.ampcs.tkpacket.scetFieldName"></entry>

--- a/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTelemetrySource.java
+++ b/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTelemetrySource.java
@@ -3,7 +3,8 @@ package edu.jhuapl.sd.sig.mmtc.tlmplugin.ampcs;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.time.OffsetDateTime;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.tlm.TimekeepingPacketParser;
 import edu.jhuapl.sd.sig.mmtc.tlmplugin.ampcs.chanvals.ChanValReadConfig;
 import edu.jhuapl.sd.sig.mmtc.tlmplugin.ampcs.chanvals.ChanValsReader;
@@ -102,6 +104,21 @@ public abstract class AmpcsTelemetrySource implements TelemetrySource {
                         "Provides any additional CLI parameters that will be passed down to the AMPCS CLI tools."
                 )
         );
+    }
+
+    @Override
+    public Map<String, String> sandboxTelemetrySourceConfiguration(MmtcConfig mmtcConfig, Path sandboxRoot, Path sandboxConfigRoot) throws IOException {
+        final Path originalTkPacketDescriptionFilePath = Paths.get(mmtcConfig.getString("telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path"));
+        final Path newTkPacketDescriptionFilePath = sandboxConfigRoot.resolve(originalTkPacketDescriptionFilePath.getFileName());
+
+        Files.copy(
+                originalTkPacketDescriptionFilePath,
+                newTkPacketDescriptionFilePath
+        );
+
+        final Map<String, String> sandboxConfigChanges = new HashMap<>();
+        sandboxConfigChanges.put("telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path", newTkPacketDescriptionFilePath.toAbsolutePath().toString());
+        return sandboxConfigChanges;
     }
 
     /**
@@ -188,10 +205,10 @@ public abstract class AmpcsTelemetrySource implements TelemetrySource {
     protected boolean packetsHaveDownlinkDataRate() throws MmtcException {
         try {
             return new TimekeepingPacketParser(
-                    new URI(ampcsConfig.getTkPacketDescriptionFile())
+                    ampcsConfig.getTkPacketDescriptionFilePath()
             ).packetsHaveDownlinkDataRate();
         } catch (Exception e) {
-            throw new MmtcException("Unable to read or parse packet definition file " + ampcsConfig.getTkPacketDescriptionFile(), e);
+            throw new MmtcException("Unable to read or parse packet definition file " + ampcsConfig.getTkPacketDescriptionFilePath(), e);
 
         }
     }
@@ -199,10 +216,10 @@ public abstract class AmpcsTelemetrySource implements TelemetrySource {
     protected boolean packetsHaveInvalidFlag() throws MmtcException {
         try {
             return new TimekeepingPacketParser(
-                    new URI(ampcsConfig.getTkPacketDescriptionFile())
+                    ampcsConfig.getTkPacketDescriptionFilePath()
             ).packetsHaveInvalidFlag();
         } catch (Exception e) {
-            throw new MmtcException("Unable to read or parse packet definition file " + ampcsConfig.getTkPacketDescriptionFile());
+            throw new MmtcException("Unable to read or parse packet definition file " + ampcsConfig.getTkPacketDescriptionFilePath());
         }
     }
 

--- a/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTelemetrySourceConfig.java
+++ b/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTelemetrySourceConfig.java
@@ -3,6 +3,8 @@ package edu.jhuapl.sd.sig.mmtc.tlmplugin.ampcs;
 import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationAppConfig;
 import edu.jhuapl.sd.sig.mmtc.tlmplugin.ampcs.chanvals.ChanValReadConfig;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 
 public class AmpcsTelemetrySourceConfig {
@@ -241,8 +243,10 @@ public class AmpcsTelemetrySourceConfig {
      *
      * @return the path to the TK description packet
      */
-    public String getTkPacketDescriptionFile() {
-        return timeCorrelationAppConfig.getString("telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri");
+    public Path getTkPacketDescriptionFilePath() {
+        return timeCorrelationAppConfig.ensureAbsolute(
+                Paths.get(timeCorrelationAppConfig.getString("telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path"))
+        );
     }
 
     public enum ActiveOscillatorSelectionMode {

--- a/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTlmArchive.java
+++ b/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTlmArchive.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -141,13 +142,13 @@ public class AmpcsTlmArchive extends AmpcsTelemetrySource {
             final String PKTLEN      = ampcsConfig.getTkPacketLengthFieldName();
 
             // Get the information on the TK packet binary file.
-            URI pktDescriptionSource;
+            Path pktDescriptionSource;
             URI binaryPktFile;
             try {
-                pktDescriptionSource = new URI(ampcsConfig.getTkPacketDescriptionFile());
+                pktDescriptionSource = ampcsConfig.getTkPacketDescriptionFilePath();
                 binaryPktFile        = new URI("file://" + packetOutputFilename);
             } catch (URISyntaxException e) {
-                throw new MmtcException("Unable to open packet description file " + ampcsConfig.getTkPacketDescriptionFile());
+                throw new MmtcException("Unable to open packet description file " + ampcsConfig.getTkPacketDescriptionFilePath());
             }
 
             TimekeepingPacketParser parser;

--- a/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTlmWithFrames.java
+++ b/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTlmWithFrames.java
@@ -12,6 +12,7 @@ import org.apache.commons.csv.CSVRecord;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -139,15 +140,15 @@ public class AmpcsTlmWithFrames extends AmpcsTelemetrySource {
             final String FRAME_VCFC  = ampcsConfig.getFrameVcfcFieldName();
 
             // Get the information on the TK packet binary file.
-            URI pktDescriptionSource;
+            Path pktDescriptionSource;
             URI binaryPktFile;
             TimekeepingPacketParser parser;
             try {
-                pktDescriptionSource = new URI(ampcsConfig.getTkPacketDescriptionFile());
+                pktDescriptionSource = ampcsConfig.getTkPacketDescriptionFilePath();
                 binaryPktFile        = new URI("file://" + packetOutputFilename);
             } catch (URISyntaxException e) {
                 throw new MmtcException("Unable to open packet description file " +
-                        ampcsConfig.getTkPacketDescriptionFile());
+                        ampcsConfig.getTkPacketDescriptionFilePath());
             }
             try {
                 parser = new TimekeepingPacketParser(pktDescriptionSource);

--- a/mmtc-plugin-ampcs/src/test/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/util/TemporaryTkConfigProperties.java
+++ b/mmtc-plugin-ampcs/src/test/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/util/TemporaryTkConfigProperties.java
@@ -44,7 +44,7 @@ public class TemporaryTkConfigProperties implements AutoCloseable {
 
     public static TemporaryTkConfigProperties withTestTkPacketDescriptionFile(String baseConfigDir) throws IOException {
         Map<String, String> overrides = new HashMap<>();
-        overrides.put("telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri", "file://" + Paths.get("../mmtc-plugin-ampcs/src/test/resources/test_tk_pkt.xml").toAbsolutePath());
+        overrides.put("telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path", Paths.get("../mmtc-plugin-ampcs/src/test/resources/test_tk_pkt.xml").toAbsolutePath().toString());
         return new TemporaryTkConfigProperties(baseConfigDir, overrides);
     }
 

--- a/mmtc-plugin-ampcs/src/test/resources/config/fixed-osc-config/TimeCorrelationConfigProperties.xml
+++ b/mmtc-plugin-ampcs/src/test/resources/config/fixed-osc-config/TimeCorrelationConfigProperties.xml
@@ -28,13 +28,13 @@
   <entry key="telemetry.source.name">AmpcsTlmArchive</entry>
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
   <!-- General options for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.chillTimeoutSec">300</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apid">123</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketSizeBytes">29</entry>
-  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri">file:///opt/local/mmtc/conf/tk_packet.xml</entry>
+  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path">/opt/local/mmtc/conf/tk_packet.xml</entry>
 
   <!-- Timekeeping packet metadata column header names for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apidFieldName">apid</entry>
@@ -138,9 +138,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///absolute/path/to/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/absolute/path/to/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///absolute/path/to/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/absolute/path/to/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-plugin-ampcs/src/test/resources/config/named-oscillators/TimeCorrelationConfigProperties.xml
+++ b/mmtc-plugin-ampcs/src/test/resources/config/named-oscillators/TimeCorrelationConfigProperties.xml
@@ -28,13 +28,13 @@
   <entry key="telemetry.source.name">AmpcsTlmArchive</entry>
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
   <!-- General options for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.chillTimeoutSec">300</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apid">123</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketSizeBytes">29</entry>
-  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri">file:///opt/local/mmtc/conf/tk_packet.xml</entry>
+  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path">/opt/local/mmtc/conf/tk_packet.xml</entry>
 
   <!-- Timekeeping packet metadata column header names for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apidFieldName">apid</entry>
@@ -142,9 +142,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///absolute/path/to/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/absolute/path/to/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///absolute/path/to/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/absolute/path/to/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-plugin-ampcs/src/test/resources/config/no-osc-config/TimeCorrelationConfigProperties.xml
+++ b/mmtc-plugin-ampcs/src/test/resources/config/no-osc-config/TimeCorrelationConfigProperties.xml
@@ -28,13 +28,13 @@
   <entry key="telemetry.source.name">AmpcsTlmArchive</entry>
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
   <!-- General options for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.chillTimeoutSec">300</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apid">123</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketSizeBytes">29</entry>
-  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri">file:///opt/local/mmtc/conf/tk_packet.xml</entry>
+  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path">/opt/local/mmtc/conf/tk_packet.xml</entry>
 
   <!-- Timekeeping packet metadata column header names for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apidFieldName">apid</entry>
@@ -129,9 +129,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///absolute/path/to/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/absolute/path/to/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///absolute/path/to/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/absolute/path/to/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-plugin-ampcs/src/test/resources/config/valid-config/TimeCorrelationConfigProperties.xml
+++ b/mmtc-plugin-ampcs/src/test/resources/config/valid-config/TimeCorrelationConfigProperties.xml
@@ -27,14 +27,14 @@
   <entry key="telemetry.source.name">AmpcsTlmArchive</entry>
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
   <!-- General options for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.frameSizeBits">1119</entry>
   <entry key="telemetry.source.plugin.ampcs.chillTimeoutSec">300</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apid">123</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketSizeBytes">29</entry>
-  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri">file:///opt/local/mmtc/conf/tk_packet.xml</entry>
+  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path">/opt/local/mmtc/conf/tk_packet.xml</entry>
 
   <!-- Timekeeping packet metadata column header names for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apidFieldName">apid</entry>
@@ -138,9 +138,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///absolute/path/to/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/absolute/path/to/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///absolute/path/to/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/absolute/path/to/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-plugin-ampcs/src/test/resources/config/with-active-radio-id/TimeCorrelationConfigProperties.xml
+++ b/mmtc-plugin-ampcs/src/test/resources/config/with-active-radio-id/TimeCorrelationConfigProperties.xml
@@ -28,13 +28,13 @@
   <entry key="telemetry.source.name">AmpcsTlmArchive</entry>
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
   <!-- General options for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.chillTimeoutSec">300</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apid">123</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketSizeBytes">29</entry>
-  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri">file:///opt/local/mmtc/conf/tk_packet.xml</entry>
+  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path">/opt/local/mmtc/conf/tk_packet.xml</entry>
 
   <!-- Timekeeping packet metadata column header names for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apidFieldName">apid</entry>
@@ -138,9 +138,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///absolute/path/to/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/absolute/path/to/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///absolute/path/to/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/absolute/path/to/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-plugin-ampcs/src/test/resources/invalid-tkPacketHeaderFineSclk-val/TimeCorrelationConfigProperties.xml
+++ b/mmtc-plugin-ampcs/src/test/resources/invalid-tkPacketHeaderFineSclk-val/TimeCorrelationConfigProperties.xml
@@ -28,7 +28,7 @@
   <entry key="telemetry.source.name">AmpcsTlmArchive</entry>
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
   <!-- General options for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.frameSizeBits">1119</entry>
@@ -36,7 +36,7 @@
   <entry key="telemetry.source.plugin.ampcs.chillTimeoutSec">300</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apid">123</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketSizeBytes">29</entry>
-  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri">file:///opt/local/mmtc/conf/tk_packet.xml</entry>
+  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path">/opt/local/mmtc/conf/tk_packet.xml</entry>
 
   <!-- Timekeeping packet metadata column header names for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apidFieldName">apid</entry>
@@ -141,9 +141,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///absolute/path/to/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/absolute/path/to/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///absolute/path/to/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/absolute/path/to/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-plugin-ampcs/src/test/resources/missing-tkPacketHeaderFineSclk-val/TimeCorrelationConfigProperties.xml
+++ b/mmtc-plugin-ampcs/src/test/resources/missing-tkPacketHeaderFineSclk-val/TimeCorrelationConfigProperties.xml
@@ -28,14 +28,14 @@
   <entry key="telemetry.source.name">AmpcsTlmArchive</entry>
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.uri">file:///absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
 
   <!-- General options for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.frameSizeBits">1119</entry>
   <entry key="telemetry.source.plugin.ampcs.chillTimeoutSec">300</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apid">123</entry>
   <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketSizeBytes">29</entry>
-  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.uri">file:///opt/local/mmtc/conf/tk_packet.xml</entry>
+  <entry key="telemetry.source.plugin.ampcs.tkpacket.tkPacketDescriptionFile.path">/opt/local/mmtc/conf/tk_packet.xml</entry>
 
   <!-- Timekeeping packet metadata column header names for AMPCS telemetry source plugin -->
   <entry key="telemetry.source.plugin.ampcs.tkpacket.apidFieldName">apid</entry>
@@ -140,9 +140,9 @@
   <entry key="filter.dataRate.maxDataRateBps">1000000</entry>
 
   <!-- Output Files -->
-  <entry key="table.rawTelemetryTable.uri">file:///absolute/path/to/output/RawTlmTable.csv</entry>
+  <entry key="table.rawTelemetryTable.path">/absolute/path/to/output/RawTlmTable.csv</entry>
   <entry key="table.rawTelemetryTable.dateTimePattern">yyyy-DDD'T'HH:mm:ss.SSSSSS</entry>
-    <entry key="table.timeHistoryFile.uri">file:///absolute/path/to/output/TimeHistoryFile.csv</entry>
+  <entry key="table.timeHistoryFile.path">/absolute/path/to/output/TimeHistoryFile.csv</entry>
   <entry key="table.timeHistoryFile.excludeColumns"></entry>
   <entry key="table.timeHistoryFile.scetUtcPrecision">6</entry>
 

--- a/mmtc-tlm-source-plugin-sdk/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/example/ExampleTelemetrySource.java
+++ b/mmtc-tlm-source-plugin-sdk/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/example/ExampleTelemetrySource.java
@@ -1,6 +1,7 @@
 package edu.jhuapl.sd.sig.mmtc.tlmplugin.example;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationAppConfig;
 import edu.jhuapl.sd.sig.mmtc.tlm.FrameSample;
 import edu.jhuapl.sd.sig.mmtc.tlm.TelemetrySource;
@@ -8,6 +9,8 @@ import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 import org.apache.commons.cli.Option;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.Duration;
@@ -16,7 +19,7 @@ import java.util.*;
 
 public class ExampleTelemetrySource implements TelemetrySource {
     // some constants to help in generating fake telemetry
-    // a typical implementation of a telemetry source will not need to know such values, as they should be read directly from the underyling source
+    // a typical implementation of a telemetry source will not need to know such values, as they should be read directly from the underlying source
     final int MAX_VCFC = 2048;
 
     private TimeCorrelationAppConfig config;
@@ -25,7 +28,7 @@ public class ExampleTelemetrySource implements TelemetrySource {
     public String getName() {
         /*
          * This is the first call that MMTC makes to any given TelemetrySource during a correlation run.
-         * It is used to determine the unique name for a TelemetrySource implementation, and is used to select the configured TelemetrySource among all available implementaitons for the run.
+         * It is used to determine the unique name for a TelemetrySource implementation, and is used to select the configured TelemetrySource among all available implementations for the run.
          */
         return "ExampleTelemetrySource";
     }
@@ -93,6 +96,15 @@ public class ExampleTelemetrySource implements TelemetrySource {
          * This is called after a call to `connect()` and one or many `get` methods. It may be called multiple times, one time for each call to `connect()`.
          * This example implementation is a no-op.
          */
+    }
+
+    /**
+     * This is called if/when MMTC has been instructed to create a sandboxed copy of itself.  This method is a hook for plugins to be able to copy their specific plugin files, if any,
+     * to the new sandboxed location, and to return a map of updated configuration key/value pairs that should be applied to the new (sandboxed) MMTC configuration.
+     */
+    @Override
+    public Map<String, String> sandboxTelemetrySourceConfiguration(MmtcConfig mmtcConfig, Path sandboxRoot, Path sandboxConfigRoot) throws IOException {
+        return Collections.emptyMap();
     }
 
     @Override

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
             library("commons-csv", "org.apache.commons:commons-csv:1.14.0")
             library("commons-lang3", "org.apache.commons:commons-lang3:3.18.0")
             library("commons-cli", "commons-cli:commons-cli:1.9.0")
+            library("commons-io", "commons-io:commons-io:2.19.0")
 
             library("log4j-api", "org.apache.logging.log4j:log4j-api:2.25.1")
             library("log4j-core", "org.apache.logging.log4j:log4j-core:2.25.1")

--- a/utils/setup-and-run-demo.sh
+++ b/utils/setup-and-run-demo.sh
@@ -11,7 +11,7 @@ export TK_CONFIG_PATH="$SCRIPT_DIR/conf"
 echo "Environment vars set"
 
 # Adjust necessary config keys
-source ./update-config-key.sh telemetry.source.plugin.rawTlmTable.tableFile.uri "FILE://$SCRIPT_DIR/RawTelemetryTable_NH_reformatted.csv" "$SCRIPT_DIR/conf/TimeCorrelationConfigProperties.xml"
+source ./update-config-key.sh telemetry.source.plugin.rawTlmTable.tableFile.path "$SCRIPT_DIR/RawTelemetryTable_NH_reformatted.csv" "$SCRIPT_DIR/conf/TimeCorrelationConfigProperties.xml"
 
 $SCRIPT_DIR/bin/mmtc 2017-342T00:00:00 2017-342T23:59:59 -F --clkchgrate-compute p
 $SCRIPT_DIR/bin/mmtc 2017-343T00:00:00 2017-343T23:59:59 -F --clkchgrate-compute i


### PR DESCRIPTION
These changes add a sandbox creation feature to MMTC, so that any user allowed to invoke the `mmtc` program can easily create a fully-independent copy of that MMTC installation (including its output product state) elsewhere on the filesystem.  These sandboxes can be run and manipulated in any fashion without affecting the original MMTC installation.  Additionally, the TelemetrySource interface is enhanced with a new method that is called as a hook during sandbox creation so telemetry source plugins can perform any copying/manipulation of their configuration as required for the new to sandbox to work identically to its source MMTC installation.

This new feature can be invoked with `bin/mmtc create-sandbox <path to new sandbox>`.

Additionally:
- Added the concept of MMTC CLI 'commands'
	- This essentially carries forward the preexisting flow of the 'rollback' command having non-correlation behavior, and is similar to other CLI interfaces that have many individual commands that can be invoked, e.g. podman
	- Supported commands are: [correlation|rollback|create-sandbox].  If no command is specified, 'correlation' is assumed, which keeps existing scripts/automation stable with prior releases
	- Changed main class from TimeCorrelationApp to MmtcCli
	- Separated configuration into an abstract MmtcConfig class and its extending concrete classes (TimeCorrelationAppConfig, RollbackConfig, MmtcSandboxCreatorConfig)
		- This was done primarily to avoid an even larger changeset (because the CLI of each command is different, and the current design ties the CLI definition to the overall configuration)
		- The separation of concerns here is only partially complete, and I expect that we'll move more configuration/logic from MmtcConfig into its subclasses over time
- Changed all URIs in config to filepaths