### PR TITLE
[#10] Plugin-provided output products

### DIFF
--- a/create-demo-zip.sh
+++ b/create-demo-zip.sh
@@ -68,5 +68,5 @@ touch $DEMO_DIR/output/.keep
 cp -r mmtc-core/src/test/resources/nh_kernels                                       $DEMO_DIR/kernels
 
 cd $DEMO_DIR
-zip -r ./mmtc-$1-demo.zip                         .
+zip -qr ./mmtc-$1-demo.zip                         .
 cp mmtc-$1-demo.zip ../distributions

--- a/docs/MMTC_Users_Guide.adoc
+++ b/docs/MMTC_Users_Guide.adoc
@@ -854,8 +854,8 @@ Please reference the configuration section for the full configuration key names 
 The overall process for implementing a new Telemetry Source plugin and providing it to MMTC for usage is:
 
 1. Writing a new Java implementation of its _TelemetrySource_ interface
-2. Building and packaging it into a Java .jar file according to the Java service convention
-3. Placing the jar file in a location accessible to MMTC and supplying matching configuration in TimeCorrelationConfigProperties.xml.
+2. Building and packaging it into a Java .jar file according to the Java ServiceLoader convention
+3. Placing the jar file in a location accessible to MMTC and supplying corresponding configuration in TimeCorrelationConfigProperties.xml.
 
 ==== Quick Start
 
@@ -904,16 +904,16 @@ The directory structure of the example Telemetry Source project is as follows:
 
 To build and use the plugin:
 
-1. Acquire the SDK artifact `mmtc-{revnumber}-tlm-source-plugin-sdk.zip`, either from a release or by building from the MMTC repository: `./gradlew :mmtc-tlm-source-plugin-sdk:createSdkDist`
+1. Acquire the SDK artifact `mmtc-{revnumber}-tlm-source-plugin-sdk.zip`, either from an MMTC release or by building from the MMTC repository: `./gradlew :mmtc-tlm-source-plugin-sdk:createSdkDist`
 2. Unzip the archive, which will create the file structure illustrated above.
 3. From the root of the SDK's Gradle project, run `./gradlew build`
 4. Configure your MMTC deployment as follows (assuming your MMTC installation is located at `/opt/local/mmtc`):
-- Copy the resulting `build/libs/mmtc-plugin-example-1.0.0-SNAPSHOT.jar` file into `/opt/local/mmtc/lib/plugins`
+- Copy the resulting `build/libs/mmtc-tlm-plugin-example-1.0.0-SNAPSHOT.jar` file into `/opt/local/mmtc/lib/plugins`
 - Apply the following configuration in `/opt/local/mmtc/conf/TimeCorrelationConfigProperties.xml`:
 
     <entry key="telemetry.source.name">ExampleTelemetrySource</entry>
     <entry key="telemetry.source.pluginDirectory">/opt/local/mmtc/lib/plugins/</entry>
-    <entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-example</entry>
+    <entry key="telemetry.source.pluginJarPrefix">mmtc-tlm-plugin-example</entry>
 
 5. Run MMTC:
 
@@ -1321,6 +1321,11 @@ Always set this value to false if using the AMPCS telemetry source plugin’s Am
 |STR
 |The pattern that is used to parse ERTs from query metadata and to write ERT to the RawTlmTable in calendar string date/time form (e.g., ISO DOY format: “yyyy-DDD’T’HH:mm:ss.SSSSSS”).
 
+|table.timeHistoryFile.create
+|OPTIONAL
+|BOOL
+|Whether the Time History File should be created (if need be) and updated with each run.  If not specified, the default value is `true`.
+
 |table.timeHistoryFile.path
 |REQUIRED
 |STR
@@ -1400,6 +1405,11 @@ Always set this value to false if using the AMPCS telemetry source plugin’s Am
 |OPTIONAL
 |STR
 |The basename of the Uplink Command File. For example, given the filename “uplinkCmd1577130458.csv”, “uplinkCmd” is the basename. Required if product.uplinkCmdFile.create is `true`.
+
+|product.plugin.outputProductNames
+|OPTIONAL
+|STR
+|A comma-separated list of names that uniquely identify plugin-provided (custom) output product types.  If this parameter is populated, additional per-custom-product parameters are also required.  Please reference <<_configuring_custom_output_products>> for details.
 
 
 |===
@@ -1720,7 +1730,11 @@ Path ID, Station ID, Station Name
 
 == Output Products
 
-=== Output SCLK Kernel
+=== Built-in Products
+
+MMTC contains built-in functionality to create and update a range of output products.  Each output product type has associated configuration that can be used to adjust the desired content of each output product.  Please refer the configuration section for full configuration details.
+
+==== Output SCLK Kernel
 
 Each time the MMTC runs, it creates a new SCLK kernel. SCLK kernels follow the NAIF specifications _(SCLK – Reference for the SPICE spacecraft clock subsystem and the Spacecraft Clock Kernel (SCLK))_ and is a primary output product. Each new SCLK kernel contains the entire contents of the previous SCLK kernel that MMTC read as input, but has one new time correlation record appended to the end. In addition, if the user has selected interpolated clock change rate computation (the default), the clock change rate of the last record of the previous kernel will be overwritten with a new and more accurate value. The new kernel will have the same name as the preceding one, except that the version number in the name will have been incremented.
 
@@ -1735,11 +1749,11 @@ For example, setting _basename_ to “europaclipper”, _sep_ to “_”, and _s
 
 MMTC writes the SCLK kernels to the directory indicated in *spice.kernel.sclk.kerneldir*. The existing input SCLK Kernel must reside in this directory and the new output SCLK kernel will be written to it.
 
-==== Input SCLK Kernel Override
+===== Input SCLK Kernel Override
 
 MMTC provides a configuration parameter *spice.kernel.sclk.inputPathOverride* that directs it to read the source (current) SCLK Kernel not from the normal *spice.kernel.sclk.kerneldir* from which it normally derives its input SCLK kernel, but from an alternate SCLK Kernel. This is intended for use only in test venues. On occasion, it is convenient when testing to read an SCLK kernel other than the one resident in the directory that the new one will be written to. This can cause versioning problems and duplicate SCLK Kernel filename errors in successive runs. Therefore, this option is only for certain test situations and should never be used operationally. To use this, set *spice.kernel.sclk.inputPathOverride* to the fully qualified path of the alternate SCLK Kernel. Remove it before running again. Successive runs will likely fail if this parameter is not removed after the first run.
 
-=== SCLK/SCET File
+==== SCLK/SCET File
 
 Each time MMTC runs, it optionally creates a new SCLK/SCET file. SCLK/SCET files follow the NAIF specifications _(Generic SCLK versus SCET Correlation File, Software Interface Specification, Rev. E, January 2012)_. This is a primary output product. The new SCLK/SCET file contains the entire contents of the previous SCLK/SCET file, but has one new time correlation record appended to the end. The version number of the file is incremented each time a new one is produced. MMTC creates the new SCLK/SCET file from the new SCLK kernel; however, in order to conform with specifications and for accurate conversions, it adds two records at every point in time where a leap second was added to world timekeeping.  For each leap second, two records will be inserted that encode the leap second at the next-higher coarse SCLK tick to the actual occurrence of the leap second.  MMTC supports both added (positive) leap seconds and removed (negative) leap seconds.
 
@@ -1756,27 +1770,168 @@ MMTC names the SCLK/SCET files by `<basename><sep><nnnn>.<suffix>`, where:
 
 For example, setting _basename_ to “europaclipper”, _sep_ to “_”, and _suffix_ to “coeff” in the configuration parameters would produce the SCLK kernel *“europaclipper_00123.coeff”*, if the previous version was 122.
 
-=== Uplink Command File
+==== Uplink Command File
 
 The Uplink Command File is an optional operations product that can be used to uplink time correlation data to the spacecraft. It is a simple CSV formatted text file with a single line in it. It contains five values: SCLK coarse, ground time in ephemeris time in seconds of epoch (ET also called TDB), ground time in TDT in seconds of epoch, the identical ground time TDT as a calendar string, and the clock change rate. The fine time SCLK (i.e., subseconds) is not included in this file because the corresponding ground time is adjusted, by an amount equal to the fine time, to a whole tick SCLK coarse time; in other words, the subseconds are subtracted from the TDB and TDT ground times. The SCLK1, TDT1, and CLKCHGRATE1 values which the flight software uses to compute ground time from SCLK derive from these. It is left to other elements of the space mission ground system to convert the values in this file to the necessary format and load them into a command for uplink. For missions that use this product, it is left to the mission’s GDS to take this file and form its contents into a command that can be uplinked. See Appendix D. for a sample of this file.
 
 This file is produced if the *product.uplinkCmdFile.create* configuration parameter is set to `true`, or if the `--generate-cmd-file` or `-c` option is provided at the command line. If the command line option is provided, it will override the configuration parameter.
 
-=== Time History File
+==== Time History File
 
 The Time History File is a cumulative product that is updated with a single record appended to its end each time the MMTC runs. It is a CSV format text file that contains records of processed time correlations (including inputs and computed values) as well as other information useful in assessing the state of the onboard clock. This file is intended for analysis purposes. Table 8 in Appendix E describes the fields in this file.
 
 MMTC creates this file upon its first execution, and appends to it with each successful run thereafter.  If this file becomes inconveniently large over the course of a mission, the records created from prior runs may be deleted (possibly having been copied elsewhere for archival purposes.)
 
-=== Raw Telemetry Table
+==== Raw Telemetry Table
 
 The Raw Telemetry Table contains the unprocessed data extracted from telemetry used in time correlation. It contains the basic SCLK, ERT, and virtual channel information. The data contained in this table, along with the associated SPICE kernels and configuration parameters, contain the information needed to run the Time Correlation application and, when necessary, to reproduce the results of a previous time correlation and its output products (SCLK kernel, SCLK/SCET file, command uplink file) without having to connect to the telemetry archive again. This is a comma separated value (CSV) formatted text file. It is useful for analysis and for later reprocessing if needed. It contains records of all frames/TK Packets in the sample set and is appended to each time the application runs. The fields in the table are described in Table 9 in the Appendix.
 
 MMTC creates this file upon its first execution, and appends to it with each successful run thereafter.  If this file becomes inconveniently large over the course of a mission, the records created from prior runs may be deleted (possibly having been copied elsewhere for archival purposes.)
 
-=== Run History File
+==== Run History File
 The Run History File is another cumulative product that records information about each successful MMTC run that is executed. While it can be useful to users for tracking things such as: the state of output products before and
 after each MMTC run; the system user responsible for each run; the time a run was executed; and more, its primary purpose is to enable output product rollback (discussed later) and therefore should never be manually modified due to risk of interfering with or preventing successful rollback in the future.
+
+=== Custom Output Products
+
+MMTC users and adaptations can declare one or many custom output products in configuration.  These custom output products are implemented by external jars (compiled against mmtc-core) which contain at least one implementation of the `OutputProductDefinitionFactory` interface.  These output product implementations:
+- must be defined as `OutputProductDefinitions` that extend either `AppendedFileOutputProductDefinition` or `EntireFileOutputProductDefinition`
+- are written last in a correlation run, and are included in the Run History file, rollback, and sandboxing functionality
+- are provided a `TimeCorrelationContext` from which to pull information about the current or past correlations
+
+The overall process for implementing a new Output Product plugin and providing it to MMTC for usage is:
+
+1. Writing a new Java implementation of its `OutputProductDefinitionFactory` interface, which its provides one or several `OutputProductDefinition` implementations
+2. Building and packaging it into a Java .jar file according to the Java ServiceLoader convention
+3. Placing the jar file in a location accessible to MMTC and supplying corresponding configuration in TimeCorrelationConfigProperties.xml.
+
+==== Quick Start
+
+MMTC includes an example standalone Gradle project that builds a functional sample Output Product plugin that can be immediately used with MMTC, and which can serve as a basis for new plugins.
+
+The directory structure of the sample project is as follows:
+
+[source, subs="attributes"]
+----
+├── build.gradle.kts
+├── docs
+│ └── MMTC_Users_Guide.pdf
+├── gradle
+│ └── wrapper
+│     ├── gradle-wrapper.jar
+│     └── gradle-wrapper.properties
+├── gradlew
+├── lib
+│ └── edu
+│     └── jhuapl
+│         └── sd
+│             └── sig
+│                 └── mmtc-core
+│                     └── {revnumber}
+│                         ├── mmtc-core-{revnumber}.jar
+│                         ├── mmtc-core-{revnumber}-javadoc.jar
+│                         ├── mmtc-core-{revnumber}.pom
+│                         └── mmtc-core-{revnumber}-sources.jar
+├── settings.gradle.kts
+└── src
+    └── main
+        ├── java
+        │ └── edu
+        │     └── jhuapl
+        │         └── sd
+        │             └── sig
+        │                 └── mmtc
+        │                     └── products
+        │                         └── definition
+        │                             ├── ExampleAppendedFileOutputProductDefinition.java
+        │                             ├── ExampleEntireFileOutputProductDefinition.java
+        │                             └── ExampleOutputProductDefinitionFactory.java
+        └── resources
+            └── META-INF
+                └── services
+                    └── edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinitionFactory
+----
+
+To build and use the plugin:
+
+1. Acquire the SDK artifact `mmtc-{revnumber}-output-plugin-sdk.zip`, either from an MMTC release or by building from the MMTC repository: `./gradlew :mmtc-output-plugin-sdk:createSdkDist`
+2. Unzip the archive, which will create the file structure illustrated above.
+3. From the root of the SDK's Gradle project, run `./gradlew build`
+4. Configure your MMTC deployment as follows (assuming your MMTC installation is located at `/opt/local/mmtc`):
+- Copy the resulting `build/libs/mmtc-output-plugin-example-1.0.0-SNAPSHOT.jar` file into `/opt/local/mmtc/lib/plugins`
+- Apply the following configuration in `/opt/local/mmtc/conf/TimeCorrelationConfigProperties.xml`:
+
+    <entry key="product.plugin.outputProductNames">CustomProduct1,CustomProduct2</entry>
+    <entry key="product.plugin.CustomProduct1.pluginDirectory">/opt/local/mmtc/lib/plugins/</entry>
+    <entry key="product.plugin.CustomProduct1.pluginJarPrefix">mmtc-output-plugin-example</entry>
+    <entry key="product.plugin.CustomProduct1.outputProductType">Example Entire File Product</entry>
+    <entry key="product.plugin.CustomProduct1.enabled">true</entry>
+    <entry key="product.plugin.CustomProduct1.config.customHeaderContent">My Custom Header Content</entry>
+    <entry key="product.plugin.CustomProduct1.config.customFooterContent">My Custom Footer Content</entry>
+    <entry key="product.plugin.CustomProduct2.pluginDirectory">/opt/local/mmtc/lib/plugins/</entry>
+    <entry key="product.plugin.CustomProduct2.pluginJarPrefix">mmtc-output-plugin-example</entry>
+    <entry key="product.plugin.CustomProduct2.outputProductType">Example Appended File Product</entry>
+    <entry key="product.plugin.CustomProduct2.enabled">true</entry>
+
+5. Run MMTC:
+
+    bin/mmtc 2017-342T00:00:00 2017-342T23:59:59 -F --clkchgrate-compute p
+
+6. View the plugin-provided output products located at:
+
+    /opt/local/mmtc/output/Example-Appended-File.csv
+    /opt/local/mmtc/output/Example-Entire-File_1001.txt
+
+
+==== Writing a new _OutputProductDefinitionFactory_ Implementation
+
+To develop a new plugin, a developer needs to implement the _OutputProductDefinitionFactory_ interface.  An implementation of _OutputProductDefinitionFactory_ performs two main tasks:
+
+1. Informing MMTC of the type of products in can create (identified by unique strings returned from `OutputProductDefinitionFactory#getApplicableTypes()`, called by MMTC on startup)
+
+2. Instantiating instances of these output product types (via `OutputProductDefinition<?> create(String type, String name, Map<String, String> config)`, called by MMTC for each enabled output product that has a type that this plugin  provides.)
+
+The returned `OutputProductDefinition` instances must be of types that extend from one of these two provided base classes:
+
+- `AppendedFileOutputProductDefinition`: plaintext products for which only one file will ever exist, and which has one or many lines appended to it with each successful time correlation (e.g. plaintext files, CSV files, logs, etc.)
+
+- `EntireFileOutputProductDefinition`: any product type which will produce a new file with each successful time correlation, and which has an advancing version number encoded in the middle of its filename (e.g. `myfile_0001.bin`)
+
+In particular, before and during implementation of a new Output Product plugin, please read and understand the Javadoc and comments in the MMTC source for at least the following classes:
+
+* edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinitionFactory
+* edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinition
+
+The following methods must be implemented for each new product type that is implemented:
+
+* For new classes extending `EntireFileOutputProductDefinition`:
+** `ProductWriteResult writeNewProduct(TimeCorrelationContext ctx)`
+** `ResolvedProductDirPrefixSuffix resolveLocation(MmtcConfig config)`
+** `boolean shouldBeWritten(TimeCorrelationContext ctx)`
+** `Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputDir)`
+* For new classes extending `AppendedFileOutputProductDefinition`:
+** `ProductWriteResult appendToProduct(TimeCorrelationContext ctx)`
+** `ResolvedProductPath resolveLocation(MmtcConfig config)`
+** `boolean shouldBeWritten(TimeCorrelationContext ctx)`
+** `Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputPath)`
+
+This implementation and all other supporting classes and/or libraries must be packaged in a jar file, along with a `META-INF/services` directory containing a service provider configuration file that identifies the class(es) that implement the OutputProductDefinitionFactory.  Please reference the above sample project for an example of a compliant implementation.
+
+==== Configuring Custom Output Products
+
+For MMTC to configure plugin-provided output products at runtime, the following configuration must be in place within MMTC's TimeCorrelationConfigProperties.xml file:
+
+* the *product.plugin.outputProductNames* configuration parameter must specify a comma-separated list of strings that provide (custom) names for each additional, plugin-provided output product
+* for each product name given in the key above, the following configuration must be specified:
+** *product.plugin.[name].pluginDirectory*: the directory containing the jar that implements this product's type
+** *product.plugin.[name].pluginJarPrefix*: the prefix of the jar that uniquely specifies the start of the plugin jar file's name within the above directory
+** *product.plugin.[name].outputProductType*: the type of the output product (that will be recognized and is able to be created by an OutputProductDefinitionFactory within the above jar)
+** *product.plugin.[name].enabled*: whether the product should be enabled (`true`) or not (`false`)
+** *product.plugin.[name].config.**: optional configuration key namespace to pass key-value configuration for this product, via its matching `OutputProductDefinitionFactory's` `create` method
+
+
+Please note that a single plugin jar may include more than one _OutputProductDefinitionFactory_ or _OutputProductDefinition_ implementations.
+
 
 == Output Product Rollback
 MMTC 1.5.0 and later provides a simple system for users to revert all of MMTC's output products back to an earlier state. Rollback makes use of the Run History File to determine which output products and

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/TimeCorrelationApp.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/TimeCorrelationApp.java
@@ -92,6 +92,7 @@ public class TimeCorrelationApp {
         }
 
         runHistoryFile = new RunHistoryFile(config.getRunHistoryFilePath(), config.getAllOutputProductDefs());
+        runHistoryFile.updateRowsForNewProducts();
         newRunHistoryFileRecord = new TableRecord(runHistoryFile.getHeaders());
         recordRunHistoryFilePreRunValues();
 
@@ -187,13 +188,15 @@ public class TimeCorrelationApp {
      * Meant to be run after all output product objects have been initialized but before they've been modified by a successful run.
      */
     private void recordRunHistoryFilePreRunValues() throws MmtcException {
-        int newRunId;
-        List<TableRecord> prevRuns = runHistoryFile.readRecords(RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS);
+        final int newRunId;
+        {
+            List<TableRecord> prevRuns = runHistoryFile.readRecords(RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS);
 
-        if (prevRuns.isEmpty()) {
-            newRunId = 1;
-        } else {
-            newRunId = Integer.parseInt(prevRuns.get(prevRuns.size()-1).getValue("Run ID")) + 1;
+            if (prevRuns.isEmpty()) {
+                newRunId = 1;
+            } else {
+                newRunId = Integer.parseInt(prevRuns.get(prevRuns.size() - 1).getValue("Run ID")) + 1;
+            }
         }
 
         ctx.runId.set(newRunId);

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/PluginProvidedProductConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/PluginProvidedProductConfig.java
@@ -1,0 +1,65 @@
+package edu.jhuapl.sd.sig.mmtc.cfg;
+
+import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PluginProvidedProductConfig {
+    public final Path pluginDir;
+    public final String pluginJarPrefix;
+    public final String outputProductType;
+    public final String outputProductName;
+    public final boolean enabled;
+    public final Map<String, String> config;
+
+    public PluginProvidedProductConfig(Path pluginDir, String pluginJarPrefix, String outputProductType, String outputProductName, boolean enabled, Map<String, String> config) {
+        this.pluginDir = pluginDir;
+        this.pluginJarPrefix = pluginJarPrefix;
+        this.outputProductType = outputProductType;
+        this.outputProductName = outputProductName;
+        this.enabled = enabled;
+        this.config = config;
+    }
+
+    public static PluginProvidedProductConfig createFrom(MmtcConfig config, String productName) throws MmtcException {
+        final String baseKey = "product.plugin." + productName;
+
+        final Path pluginDir = Paths.get(config.getEnsureNotEmpty(baseKey + ".pluginDirectory"));
+        final String pluginJarPrefix = config.getEnsureNotEmpty(baseKey + ".pluginJarPrefix");
+        final String outputProductType = config.getEnsureNotEmpty(baseKey + ".outputProductType");
+        final boolean enabled = config.getBoolean(baseKey + ".enabled");
+
+        final Map<String, String> outputProductConfig = new HashMap<>();
+        final String productConfigKeyPrefix = baseKey + ".config";
+        for (String productConfigKey : config.getKeysWithPrefix(productConfigKeyPrefix)) {
+            outputProductConfig.put(
+                    productConfigKey.replace(productConfigKeyPrefix + ".", ""),
+                    config.getString(productConfigKey)
+            );
+        }
+
+        return new PluginProvidedProductConfig(
+                pluginDir,
+                pluginJarPrefix,
+                outputProductType,
+                productName,
+                enabled,
+                outputProductConfig
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "PluginProvidedProductConfig{" +
+                "pluginDir=" + pluginDir +
+                ", pluginJarPrefix='" + pluginJarPrefix + '\'' +
+                ", outputProductType='" + outputProductType + '\'' +
+                ", outputProductName='" + outputProductName + '\'' +
+                ", enabled=" + enabled +
+                ", config=" + config +
+                '}';
+    }
+}

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/TimeCorrelationAppConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/TimeCorrelationAppConfig.java
@@ -81,7 +81,6 @@ public class TimeCorrelationAppConfig extends MmtcConfig{
         logger.debug(toString());
     }
 
-
     public TelemetrySource getTelemetrySource() {
         return telemetrySource;
     }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/correlation/TimeCorrelationContext.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/correlation/TimeCorrelationContext.java
@@ -11,9 +11,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
-// todo: make this immutable somehow (maybe adopt set-once or builder pattern)
 public class TimeCorrelationContext {
     public final CorrelationInfo correlation = new CorrelationInfo();
     public final GeometryInfo geometry = new GeometryInfo();
@@ -21,14 +19,16 @@ public class TimeCorrelationContext {
 
     public final TimeCorrelationAppConfig config;
     public final TelemetrySource telemetrySource;
-    private final List<String> warnings;
     public final OffsetDateTime appRunTime;
+    public final Settable<Integer> runId = new Settable<>();
 
     public final Settable<SclkKernel> currentSclkKernel = new Settable<>();
     public final Settable<String> newSclkVersionString = new Settable<>();
     public final Settable<Path> newSclkKernelPath = new Settable<>();
     public final Settable<Integer> tk_sclk_fine_tick_modulus = new Settable<>();
     public final Settable<Integer> sclk_kernel_fine_tick_modulus = new Settable<>();
+
+    private final List<String> warnings;
 
     public TimeCorrelationContext(final TimeCorrelationAppConfig config) {
         this.config = config;

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/AppendedFileOutputProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/AppendedFileOutputProductDefinition.java
@@ -3,6 +3,8 @@ package edu.jhuapl.sd.sig.mmtc.products.definition;
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
 import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductPath;
 import edu.jhuapl.sd.sig.mmtc.rollback.TimeCorrelationRollback;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -11,7 +13,10 @@ import java.util.Optional;
 
 import static edu.jhuapl.sd.sig.mmtc.app.MmtcCli.USER_NOTICE;
 
-public abstract class AppendedFileOutputProductDefinition extends OutputProductDefinition<OutputProductDefinition.ResolvedProductPath> {
+/**
+ * Defines an output product that is represented by a single text file, which has one or many lines appended to it with each successful time correlation.
+ */
+public abstract class AppendedFileOutputProductDefinition extends OutputProductDefinition<ResolvedProductPath> {
     private static final Logger logger = LogManager.getLogger();
 
     public AppendedFileOutputProductDefinition(String name) {
@@ -20,15 +25,13 @@ public abstract class AppendedFileOutputProductDefinition extends OutputProductD
 
     @Override
     public final ProductWriteResult write(TimeCorrelationContext ctx) throws MmtcException {
-        final ProductWriteResult pwr = writeToProduct(ctx);
+        final ProductWriteResult pwr = appendToProduct(ctx);
         logger.info(USER_NOTICE, String.format("Appended to the %s located at %s", name, pwr.path));
         return pwr;
     }
 
-    public abstract ProductWriteResult writeToProduct(TimeCorrelationContext ctx) throws MmtcException;
-
     @Override
-    public TimeCorrelationRollback.ProductRollbackOperation<ResolvedProductPath> getRollbackOperation(RollbackConfig config, Optional<String> newLatestProductVersion) throws MmtcException {
+    public final TimeCorrelationRollback.ProductRollbackOperation<ResolvedProductPath> getRollbackOperation(RollbackConfig config, Optional<String> newLatestProductVersion) throws MmtcException {
         if (! newLatestProductVersion.isPresent()) {
             // if we're rolling back to the initial state, then delete the entire file
             return new TimeCorrelationRollback.SingleFileDeletionOperation(resolveLocation(config));
@@ -37,4 +40,13 @@ public abstract class AppendedFileOutputProductDefinition extends OutputProductD
             return new TimeCorrelationRollback.TableTruncationOperation(resolveLocation(config), newLatestProductVersion);
         }
     }
+
+    /**
+     * Append new information to this output product on the filesystem (creating the file if it does not yet exist)
+     *
+     * @param ctx the current time correlation context, to read input and time correlation information from
+     * @return the result of writing this product
+     * @throws MmtcException if the product was not successfully written
+     */
+    public abstract ProductWriteResult appendToProduct(TimeCorrelationContext ctx) throws MmtcException;
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/BuiltInOutputProductDefinitionFactory.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/BuiltInOutputProductDefinitionFactory.java
@@ -1,0 +1,30 @@
+package edu.jhuapl.sd.sig.mmtc.products.definition;
+
+import java.util.*;
+
+public class BuiltInOutputProductDefinitionFactory implements OutputProductDefinitionFactory {
+    public static final List<String> BUILT_IN_PRODUCT_TYPES = Arrays.asList("SCLK Kernel", "SCLK-SCET File", "Time History File", "Raw Telemetry Table", "Uplink Command File");
+
+    @Override
+    public List<String> getApplicableTypes() {
+        return new ArrayList<>(BUILT_IN_PRODUCT_TYPES);
+    }
+
+    @Override
+    public OutputProductDefinition<?> create(String type, String name, Map<String, String> config) {
+        // unlike plugins, we assume these to be 'singleton' output products (in that the given name does not matter, and they will always be assigned the default 'name' of the built-in instance of this product)
+        // (this will change if MMTC is ever enhanced to e.g. maintain two separate SCLK kernel lineages)
+        // as such, they are not provided a name parameter
+        // also, as another exemption, they do not read a config object, and instead read their configuration directly from a TimeCorrelationAppConfig as they were made before the current convention (though again, this may be standardized to the same pattern as the plugin outputs)
+
+        switch(type) {
+            case "SCLK Kernel": return new SclkKernelProductDefinition();
+            case "SCLK-SCET File": return new SclkScetProductDefinition();
+            case "Raw Telemetry Table": return new RawTlmTableProductDefinition();
+            case "Time History File": return new TimeHistoryFileProductDefinition();
+            case "Uplink Command File": return new UplinkCommandFileProductDefinition();
+            default:
+                throw new IllegalArgumentException("No such built-in product type: " + type);
+        }
+    }
+}

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/EntireFileOutputProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/EntireFileOutputProductDefinition.java
@@ -3,6 +3,8 @@ package edu.jhuapl.sd.sig.mmtc.products.definition;
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
 import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductDirPrefixSuffix;
 import edu.jhuapl.sd.sig.mmtc.rollback.TimeCorrelationRollback;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -11,7 +13,10 @@ import java.util.Optional;
 
 import static edu.jhuapl.sd.sig.mmtc.app.MmtcCli.USER_NOTICE;
 
-public abstract class EntireFileOutputProductDefinition extends OutputProductDefinition<OutputProductDefinition.ResolvedProductDirAndPrefix> {
+/**
+ * Defines an output product that is represented by multiple individual files (one being produced with each successful time correlation.)
+ */
+public abstract class EntireFileOutputProductDefinition extends OutputProductDefinition<ResolvedProductDirPrefixSuffix> {
     private static final Logger logger = LogManager.getLogger();
 
     public EntireFileOutputProductDefinition(final String name) {
@@ -25,8 +30,6 @@ public abstract class EntireFileOutputProductDefinition extends OutputProductDef
         return pwr;
     }
 
-    public abstract ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException;
-
     @Override
     public final TimeCorrelationRollback.MultiFileDeletionOperation getRollbackOperation(RollbackConfig config, Optional<String> newLatestProductVersion) throws MmtcException {
         return new TimeCorrelationRollback.MultiFileDeletionOperation(
@@ -34,4 +37,14 @@ public abstract class EntireFileOutputProductDefinition extends OutputProductDef
                 newLatestProductVersion
         );
     }
+
+    /**
+     * Write a new copy of this output product to the filesystem
+     *
+     * @param ctx the current time correlation context, to read input and time correlation information from
+     * @return the result of writing this product
+     * @throws MmtcException if the product was not successfully written
+     */
+    public abstract ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException;
+
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/OutputProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/OutputProductDefinition.java
@@ -1,81 +1,93 @@
 package edu.jhuapl.sd.sig.mmtc.products.definition;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
-import edu.jhuapl.sd.sig.mmtc.products.model.AbstractTimeCorrelationTable;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductLocation;
 import edu.jhuapl.sd.sig.mmtc.rollback.TimeCorrelationRollback;
+import edu.jhuapl.sd.sig.mmtc.util.Settable;
 
 import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.Optional;
 
-public abstract class OutputProductDefinition<T extends OutputProductDefinition.ResolvedProductLocation> {
-    public static List<OutputProductDefinition<?>> all() {
-        List<OutputProductDefinition<?>> all = new ArrayList<>(Arrays.asList(
-                new SclkKernelProductDefinition(),
-                new SclkScetProductDefinition(),
-                new TimeHistoryFileProductDefinition(),
-                new RawTlmTableProductDefinition(),
-                new UplinkCommandFileProductDefinition()
-        ));
+/**
+ * Defines common fields and methods common across all OutputProductDefinition implementations.
+ *
+ * @param <T> the type of ResolvedProductLocation that applies to the output product definition
+ */
+public abstract class OutputProductDefinition<T extends ResolvedProductLocation> {
+    protected final String name;
+    protected final Settable<Boolean> isBuiltIn = new Settable<>();
 
-        // ensure product definitions provide unique names
-        if (all.stream().map(def -> def.name).collect(Collectors.toSet()).size() != all.size()) {
-            throw new IllegalStateException("Please check your loaded configuration and/or plugins to ensure all output products have unique names.");
-        }
-
-        return Collections.unmodifiableList(all);
-    }
-
-    public final String name;
-
-    public OutputProductDefinition(String name) {
+    protected OutputProductDefinition(String name) {
         this.name = name;
     }
 
-    public abstract T resolveLocation(RollbackConfig config) throws MmtcException;
+    /**
+     * @return the name of the instance of the output product definition; must be unique at MMTC runtime
+     */
+    public final String getName() {
+        return this.name;
+    }
 
-    public abstract ProductWriteResult write(TimeCorrelationContext context) throws MmtcException;
+    public final void setIsBuiltIn(boolean newIsBuiltInStatus) {
+        isBuiltIn.set(newIsBuiltInStatus);
+    }
 
-    public abstract TimeCorrelationRollback.ProductRollbackOperation<?> getRollbackOperation(RollbackConfig config, Optional<String> newLatestProductVersion) throws MmtcException;
 
+    public final boolean isBuiltIn() {
+        return isBuiltIn.get();
+    }
+
+    /**
+     * 'Resolve' the location of the output product file(s) on disk for this definition.
+     *
+     * @param config the loaded MMTC configuration
+     * @return the resolved product location, given MMTC's configuration
+     * @throws MmtcException if any problem is encountered while determining the resolved product location
+     */
+    public abstract T resolveLocation(MmtcConfig config) throws MmtcException;
+
+    /**
+     * Where this product should be written, given the current time correlation
+     *
+     * @param context an object describing the time correlation inputs and results, possibly to be used in determining whether an output product should be written
+     * @return true if the product should be written, false otherwise
+     */
     public abstract boolean shouldBeWritten(TimeCorrelationContext context);
 
-    public interface ResolvedProductLocation {
-    }
+    /**
+     * Write the product to the filesystem.  Called once per successful time correlation run.
+     *
+     * @param context an object describing the time correlation inputs and results, possibly to help inform the contents of the product
+     * @return a ProductWriteResult containing the path to which updates were written as well as the new product 'version' (either a counter in the filename, or the new number of lines in the file)
+     * @throws MmtcException if there is an issue in writing the output product to disk
+     */
+    public abstract ProductWriteResult write(TimeCorrelationContext context) throws MmtcException;
 
-    public static class ResolvedProductDirAndPrefix implements ResolvedProductLocation {
-        public final Path containingDirectory;
-        public final String filenamePrefix;
+    /**
+     * Assemble a ProductRollbackOperation describing the action to take in rolling back the version of the product output file(s) to an earlier version.
+     *
+     * @param config the loaded MMTC configuration
+     * @param newLatestProductVersion the product version that will become the newest after the rollback operation completes
+     * @return the assembled ProductRollbackOperation object describing the operation to execute
+     * @throws MmtcException if there is an issue in calculating the rollback operation
+     */
+    public abstract TimeCorrelationRollback.ProductRollbackOperation<?> getRollbackOperation(RollbackConfig config, Optional<String> newLatestProductVersion) throws MmtcException;
 
-        public ResolvedProductDirAndPrefix(Path containingDirectory, String filenamePrefix) {
-            this.containingDirectory = containingDirectory;
-            this.filenamePrefix = filenamePrefix;
-        }
-    }
+    /**
+     * Returns a map of configuration keys to update to new values during sandbox creation, given the original
+     * MMTC configuration and the new directory where the MMTC sandbox will write further copies of this output product.
+     *
+     * Plugin-defined products are only permitted to update config keys with the prefix `product.plugin.[name].config.`
+     *
+     * @param originalConfig the original (non-sandboxed) MMTC configuration
+     * @param newProductOutputDir the new directory where the MMTC sandbox will write further copies of this output product
+     * @return a Map containing keys with values that should be changed for the new sandbox
+     */
+    public abstract Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputDir);
 
-    public static class ResolvedProductPath implements ResolvedProductLocation {
-        public final Path pathToProduct;
-        public final AbstractTimeCorrelationTable table;
-
-        public ResolvedProductPath(Path pathToProduct, AbstractTimeCorrelationTable table) {
-            this.pathToProduct = pathToProduct;
-            this.table = table;
-        }
-    }
-
-    public static class ProductWriteResult {
-        public final Path path;
-        public final String newVersion;
-
-        public ProductWriteResult(Path path, String newVersion) {
-            this.path = path;
-            this.newVersion = newVersion;
-        }
-
-        public ProductWriteResult(Path path, int newVersion) {
-            this(path, Integer.toString(newVersion));
-        }
-    }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/OutputProductDefinitionFactory.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/OutputProductDefinitionFactory.java
@@ -1,0 +1,11 @@
+package edu.jhuapl.sd.sig.mmtc.products.definition;
+
+import java.util.List;
+import java.util.Map;
+
+public interface OutputProductDefinitionFactory {
+    // this is a list, not a set, to preserve stable ordering (for e.g. the Run History File's use)
+    List<String> getApplicableTypes();
+
+    OutputProductDefinition<?> create(String type, String name, Map<String, String> config);
+}

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/RawTlmTableProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/RawTlmTableProductDefinition.java
@@ -1,9 +1,15 @@
 package edu.jhuapl.sd.sig.mmtc.products.definition;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
-import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductPath;
 import edu.jhuapl.sd.sig.mmtc.products.model.RawTelemetryTable;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RawTlmTableProductDefinition extends AppendedFileOutputProductDefinition {
     public RawTlmTableProductDefinition() {
@@ -11,11 +17,8 @@ public class RawTlmTableProductDefinition extends AppendedFileOutputProductDefin
     }
 
     @Override
-    public ResolvedProductPath resolveLocation(RollbackConfig config) {
-        return new ResolvedProductPath(
-                config.getRawTelemetryTablePath(),
-                new RawTelemetryTable(config.getRawTelemetryTablePath())
-        );
+    public ResolvedProductPath resolveLocation(MmtcConfig config) {
+        return new ResolvedProductPath(config.getRawTelemetryTablePath());
     }
 
     @Override
@@ -24,7 +27,14 @@ public class RawTlmTableProductDefinition extends AppendedFileOutputProductDefin
     }
 
     @Override
-    public ProductWriteResult writeToProduct(TimeCorrelationContext context) throws MmtcException {
+    public ProductWriteResult appendToProduct(TimeCorrelationContext context) throws MmtcException {
         return RawTelemetryTable.appendCorrelationFrameSamplesToRawTelemetryTable(context);
+    }
+
+    @Override
+    public Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputPath) {
+        final Map<String, String> confUpdates = new HashMap<>();
+        confUpdates.put("table.rawTelemetryTable.path", newProductOutputPath.toString());
+        return confUpdates;
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkKernelProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkKernelProductDefinition.java
@@ -1,9 +1,15 @@
 package edu.jhuapl.sd.sig.mmtc.products.definition;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
-import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductDirPrefixSuffix;
 import edu.jhuapl.sd.sig.mmtc.products.model.SclkKernel;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Describes the set of SCLK kernel output products that MMTC performs operations on.
@@ -15,10 +21,11 @@ public class SclkKernelProductDefinition extends EntireFileOutputProductDefiniti
     }
 
     @Override
-    public ResolvedProductDirAndPrefix resolveLocation(RollbackConfig conf) {
-        return new ResolvedProductDirAndPrefix(
+    public ResolvedProductDirPrefixSuffix resolveLocation(MmtcConfig conf) {
+        return new ResolvedProductDirPrefixSuffix(
                 conf.getSclkKernelOutputDir().toAbsolutePath(),
-                conf.getSclkKernelBasename()
+                conf.getSclkKernelBasename(),
+                SclkKernel.FILE_SUFFIX
         );
     }
 
@@ -36,5 +43,12 @@ public class SclkKernelProductDefinition extends EntireFileOutputProductDefiniti
     @Override
     public boolean shouldBeWritten(TimeCorrelationContext context) {
         return true;
+    }
+
+    @Override
+    public Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputDir) {
+        final Map<String, String> confUpdates = new HashMap<>();
+        confUpdates.put("spice.kernel.sclk.kerneldir", newProductOutputDir.toAbsolutePath().toString());
+        return confUpdates;
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkScetProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkScetProductDefinition.java
@@ -1,10 +1,16 @@
 package edu.jhuapl.sd.sig.mmtc.products.definition;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
-import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductDirPrefixSuffix;
 import edu.jhuapl.sd.sig.mmtc.products.model.SclkKernel;
 import edu.jhuapl.sd.sig.mmtc.products.model.SclkScetFile;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Describes the set of SCLK kernel output products that MMTC performs operations on.
@@ -16,12 +22,13 @@ public class SclkScetProductDefinition extends EntireFileOutputProductDefinition
     }
 
     @Override
-    public ResolvedProductDirAndPrefix resolveLocation(RollbackConfig conf) throws MmtcException {
+    public ResolvedProductDirPrefixSuffix resolveLocation(MmtcConfig conf) throws MmtcException {
         conf.validateSclkScetConfiguration();
 
-        return new ResolvedProductDirAndPrefix(
+        return new ResolvedProductDirPrefixSuffix(
                 conf.getSclkScetOutputDir().toAbsolutePath(),
-                conf.getSclkScetFileBasename()
+                conf.getSclkScetFileBasename(),
+                conf.getSclkScetFileSuffix()
         );
     }
 
@@ -39,5 +46,12 @@ public class SclkScetProductDefinition extends EntireFileOutputProductDefinition
     @Override
     public ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException {
       return SclkScetFile.writeNewProduct(ctx);
+    }
+
+    @Override
+    public Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputDir) {
+        final Map<String, String> confUpdates = new HashMap<>();
+        confUpdates.put("product.sclkScetFile.dir", newProductOutputDir.toAbsolutePath().toString());
+        return confUpdates;
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/TimeHistoryFileProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/TimeHistoryFileProductDefinition.java
@@ -1,19 +1,15 @@
 package edu.jhuapl.sd.sig.mmtc.products.definition;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
-import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
-import edu.jhuapl.sd.sig.mmtc.products.model.TableRecord;
-import edu.jhuapl.sd.sig.mmtc.products.model.TextProductException;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductPath;
 import edu.jhuapl.sd.sig.mmtc.products.model.TimeHistoryFile;
-import edu.jhuapl.sd.sig.mmtc.tlm.FrameSample;
-import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
-import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 
-import java.math.RoundingMode;
-import java.text.DecimalFormat;
+import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 public class TimeHistoryFileProductDefinition extends AppendedFileOutputProductDefinition {
     public TimeHistoryFileProductDefinition() {
@@ -21,20 +17,24 @@ public class TimeHistoryFileProductDefinition extends AppendedFileOutputProductD
     }
 
     @Override
-    public ResolvedProductPath resolveLocation(RollbackConfig config) {
-        return new ResolvedProductPath(
-                config.getTimeHistoryFilePath(),
-                new TimeHistoryFile(config.getTimeHistoryFilePath())
-        );
+    public ResolvedProductPath resolveLocation(MmtcConfig config) {
+        return new ResolvedProductPath(config.getTimeHistoryFilePath());
     }
 
     @Override
-    public boolean shouldBeWritten(TimeCorrelationContext context) {
-        return true;
+    public boolean shouldBeWritten(TimeCorrelationContext ctx) {
+        return ctx.config.createTimeHistoryFile();
     }
 
     @Override
-    public ProductWriteResult writeToProduct(TimeCorrelationContext ctx) throws MmtcException {
+    public ProductWriteResult appendToProduct(TimeCorrelationContext ctx) throws MmtcException {
         return TimeHistoryFile.appendRowFor(ctx);
+    }
+
+    @Override
+    public Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputPath) {
+        final Map<String, String> confUpdates = new HashMap<>();
+        confUpdates.put("table.timeHistoryFile.path", newProductOutputPath.toString());
+        return confUpdates;
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/UplinkCommandFileProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/UplinkCommandFileProductDefinition.java
@@ -1,11 +1,16 @@
 package edu.jhuapl.sd.sig.mmtc.products.definition;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
-import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductDirPrefixSuffix;
 import edu.jhuapl.sd.sig.mmtc.products.model.*;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Describes the set of SCLK kernel output products that MMTC performs operations on.
@@ -17,12 +22,13 @@ public class UplinkCommandFileProductDefinition extends EntireFileOutputProductD
     }
 
     @Override
-    public ResolvedProductDirAndPrefix resolveLocation(RollbackConfig conf) throws MmtcException {
+    public ResolvedProductDirPrefixSuffix resolveLocation(MmtcConfig conf) throws MmtcException {
         conf.validateUplinkCmdFileConfiguration();
 
-        return new ResolvedProductDirAndPrefix(
+        return new ResolvedProductDirPrefixSuffix(
                 Paths.get(conf.getUplinkCmdFileDir()).toAbsolutePath(),
-                conf.getUplinkCmdFileBasename()
+                conf.getUplinkCmdFileBasename(),
+                UplinkCmdFile.FILE_SUFFIX
         );
     }
 
@@ -40,5 +46,12 @@ public class UplinkCommandFileProductDefinition extends EntireFileOutputProductD
     @Override
     public ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException {
         return UplinkCmdFile.writeNewProduct(ctx);
+    }
+
+    @Override
+    public Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputDir) {
+        final Map<String, String> confUpdates = new HashMap<>();
+        confUpdates.put("product.uplinkCmdFile.outputDir", newProductOutputDir.toAbsolutePath().toString());
+        return confUpdates;
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/util/ProductWriteResult.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/util/ProductWriteResult.java
@@ -1,0 +1,17 @@
+package edu.jhuapl.sd.sig.mmtc.products.definition.util;
+
+import java.nio.file.Path;
+
+public class ProductWriteResult {
+    public final Path path;
+    public final String newVersion;
+
+    public ProductWriteResult(Path path, String newVersion) {
+        this.path = path;
+        this.newVersion = newVersion;
+    }
+
+    public ProductWriteResult(Path path, int newVersion) {
+        this(path, Integer.toString(newVersion));
+    }
+}

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/util/ResolvedProductDirPrefixSuffix.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/util/ResolvedProductDirPrefixSuffix.java
@@ -1,0 +1,15 @@
+package edu.jhuapl.sd.sig.mmtc.products.definition.util;
+
+import java.nio.file.Path;
+
+public class ResolvedProductDirPrefixSuffix implements ResolvedProductLocation {
+    public final Path containingDirectory;
+    public final String filenamePrefix;
+    public final String filenameSuffix;
+
+    public ResolvedProductDirPrefixSuffix(Path containingDirectory, String filenamePrefix, String filenameSuffix) {
+        this.containingDirectory = containingDirectory;
+        this.filenamePrefix = filenamePrefix;
+        this.filenameSuffix = filenameSuffix;
+    }
+}

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/util/ResolvedProductLocation.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/util/ResolvedProductLocation.java
@@ -1,0 +1,4 @@
+package edu.jhuapl.sd.sig.mmtc.products.definition.util;
+
+public interface ResolvedProductLocation {
+}

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/util/ResolvedProductPath.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/util/ResolvedProductPath.java
@@ -1,0 +1,11 @@
+package edu.jhuapl.sd.sig.mmtc.products.definition.util;
+
+import java.nio.file.Path;
+
+public class ResolvedProductPath implements ResolvedProductLocation {
+    public final Path pathToProduct;
+
+    public ResolvedProductPath(Path pathToProduct) {
+        this.pathToProduct = pathToProduct;
+    }
+}

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RawTelemetryTable.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RawTelemetryTable.java
@@ -2,7 +2,7 @@ package edu.jhuapl.sd.sig.mmtc.products.model;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
-import edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinition;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.tlm.FrameSample;
 
 import java.nio.file.Path;
@@ -62,7 +62,7 @@ public class RawTelemetryTable extends AbstractTimeCorrelationTable {
      * @throws MmtcException if there's an unhandled issue writing the raw telemetry table
      * @return a ProductWriteResult describing the updated product
      */
-    public static OutputProductDefinition.ProductWriteResult appendCorrelationFrameSamplesToRawTelemetryTable(TimeCorrelationContext context) throws MmtcException {
+    public static ProductWriteResult appendCorrelationFrameSamplesToRawTelemetryTable(TimeCorrelationContext context) throws MmtcException {
         final RawTelemetryTable rawTlmTable = new RawTelemetryTable(context.config.getRawTelemetryTablePath());
 
         for (FrameSample sample : context.correlation.target.get().getSampleSet()) {
@@ -71,7 +71,7 @@ public class RawTelemetryTable extends AbstractTimeCorrelationTable {
             rawTlmTable.writeRecord(rec);
         }
 
-        return new OutputProductDefinition.ProductWriteResult(
+        return new ProductWriteResult(
                 context.config.getRawTelemetryTablePath(),
                 rawTlmTable.getLastLineNumber()
         );

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RunHistoryFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RunHistoryFile.java
@@ -25,51 +25,17 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
     public static final String RUN_USER = "Run User";
     public static final String CLI_ARGS = "MMTC Invocation Args Used";
 
-    /*
-    public static final String PRERUN_SCLK = "Latest SCLK Kernel Pre-run";
-    public static final String POSTRUN_SCLK = "Latest SCLK Kernel Post-run";
-    public static final String PRERUN_SCLKSCET = "Latest SCLKSCET File Pre-run";
-    public static final String POSTRUN_SCLKSCET = "Latest SCLKSCET File Post-run";
-    public static final String PRERUN_TIMEHIST = "Latest TimeHistoryFile Line Pre-run";
-    public static final String POSTRUN_TIMEHIST = "Latest TimeHistoryFile Line Post-run";
-    public static final String PRERUN_RAWTLMTABLE = "Latest RawTlmTable Line Pre-run";
-    public static final String POSTRUN_RAWTLMTABLE = "Latest RawTlmTable Line Post-run";
-    public static final String PRERUN_UPLINKCMD = "Latest Uplink Command File Pre-run";
-    public static final String POSTRUN_UPLINKCMD = "Latest Uplink Command File Post-run";
-     */
+    private final List<String> headers;
 
     public enum RollbackEntryOption {
         IGNORE_ROLLBACKS,
         INCLUDE_ROLLBACKS
     }
 
-    public RunHistoryFile(Path path) {
+    public RunHistoryFile(Path path, List<OutputProductDefinition<?>> allOutputProdDefs) {
         super(path);
-    }
 
-    public static String getPreRunProductColNameFor(OutputProductDefinition<?> def) {
-        if (def instanceof EntireFileOutputProductDefinition) {
-            return String.format("Latest %s Pre-run", def.name);
-        } else if (def instanceof AppendedFileOutputProductDefinition) {
-            return String.format("Latest %s Line Pre-run", def.name);
-        } else {
-            throw new IllegalArgumentException("Unknown product type: " + def.getClass().getSimpleName());
-        }
-    }
-
-    public static String getPostRunProductColNameFor(OutputProductDefinition<?> def) {
-        if (def instanceof EntireFileOutputProductDefinition) {
-            return String.format("Latest %s Post-run", def.name);
-        } else if (def instanceof AppendedFileOutputProductDefinition) {
-            return String.format("Latest %s Line Post-run", def.name);
-        } else {
-            throw new IllegalArgumentException("Unknown product type: " + def.getClass().getSimpleName());
-        }
-    }
-
-    @Override
-    public List<String> getHeaders() {
-        List<String> headers =  new ArrayList<>(Arrays.asList(
+        final List<String> headers = new ArrayList<>(Arrays.asList(
                 RUN_TIME,
                 RUN_ID,
                 ROLLEDBACK,
@@ -77,13 +43,36 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
                 CLI_ARGS
         ));
 
-        OutputProductDefinition.all().forEach(def -> {
+        allOutputProdDefs.forEach(def -> {
             headers.add(getPreRunProductColNameFor(def));
             headers.add(getPostRunProductColNameFor(def));
         });
 
-        logger.info("Run History File headers: " + headers.toString());
+        this.headers = Collections.unmodifiableList(headers);
+    }
 
+    public static String getPreRunProductColNameFor(OutputProductDefinition<?> def) {
+        if (def instanceof EntireFileOutputProductDefinition) {
+            return String.format("Latest %s Pre-run", def.getName());
+        } else if (def instanceof AppendedFileOutputProductDefinition) {
+            return String.format("Latest %s Line Pre-run", def.getName());
+        } else {
+            throw new IllegalArgumentException("Unknown product type: " + def.getClass().getSimpleName());
+        }
+    }
+
+    public static String getPostRunProductColNameFor(OutputProductDefinition<?> def) {
+        if (def instanceof EntireFileOutputProductDefinition) {
+            return String.format("Latest %s Post-run", def.getName());
+        } else if (def instanceof AppendedFileOutputProductDefinition) {
+            return String.format("Latest %s Line Post-run", def.getName());
+        } else {
+            throw new IllegalArgumentException("Unknown product type: " + def.getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public List<String> getHeaders() {
         return headers;
     }
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RunHistoryFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RunHistoryFile.java
@@ -15,6 +15,7 @@ import java.util.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class RunHistoryFile extends AbstractTimeCorrelationTable {
     private static final Logger logger = LogManager.getLogger();
@@ -26,29 +27,106 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
     public static final String CLI_ARGS = "MMTC Invocation Args Used";
 
     private final List<String> headers;
+    private final List<String> newOutputProductHeadersToEstablishEmptyVersionsFor;
+    private final List<DeconfiguredOutputProductColPair> deconfiguredOutputProductsToTrack;
 
     public enum RollbackEntryOption {
         IGNORE_ROLLBACKS,
         INCLUDE_ROLLBACKS
     }
 
-    public RunHistoryFile(Path path, List<OutputProductDefinition<?>> allOutputProdDefs) {
+    public static class DeconfiguredOutputProductColPair {
+        public final String preRunColName;
+        public final String postRunColName;
+
+        private DeconfiguredOutputProductColPair(String preRunColName, String postRunColName) {
+            this.preRunColName = preRunColName;
+            this.postRunColName = postRunColName;
+        }
+
+        @Override
+        public String toString() {
+            return "DeconfiguredOutputProductColPair{" +
+                    "preRunColName='" + preRunColName + '\'' +
+                    ", postRunColName='" + postRunColName + '\'' +
+                    '}';
+        }
+    }
+
+    public RunHistoryFile(Path path, List<OutputProductDefinition<?>> allOutputProdDefs) throws MmtcException {
         super(path);
 
-        final List<String> headers = new ArrayList<>(Arrays.asList(
-                RUN_TIME,
-                RUN_ID,
-                ROLLEDBACK,
-                RUN_USER,
-                CLI_ARGS
-        ));
+        if (getFile().exists()) {
+            // if the file exists, read the order of its columns and update as necessary
+            // reading from disk helps ensure a stable ordering of product names, even when optional products are deconfigured
 
-        allOutputProdDefs.forEach(def -> {
-            headers.add(getPreRunProductColNameFor(def));
-            headers.add(getPostRunProductColNameFor(def));
-        });
+            final List<String> currentHeaders = new ArrayList<>(readExistingHeadersFromFile());
+            final List<String> newHeaders = new ArrayList<>();
 
-        this.headers = Collections.unmodifiableList(headers);
+            // look over all currently-configured output products to check whether there are now output product plugins defined since the last run
+            allOutputProdDefs.forEach(def -> {
+                final String prodPreRunColName = getPreRunProductColNameFor(def);
+                final String prodPostRunColName = getPostRunProductColNameFor(def);
+
+                if (! currentHeaders.contains(prodPreRunColName)) {
+                    currentHeaders.add(prodPreRunColName);
+                    newHeaders.add(prodPreRunColName);
+                }
+
+                if (! currentHeaders.contains(prodPostRunColName)) {
+                    currentHeaders.add(prodPostRunColName);
+                    newHeaders.add(prodPostRunColName);
+                }
+            });
+
+            this.headers = Collections.unmodifiableList(currentHeaders);
+            this.newOutputProductHeadersToEstablishEmptyVersionsFor = Collections.unmodifiableList(newHeaders);
+            this.deconfiguredOutputProductsToTrack = Collections.unmodifiableList(determineDeconfiguredProducts(allOutputProdDefs));
+        } else {
+            // if the file does not exist, establish a new column ordering
+
+            // default columns
+            final List<String> headers = new ArrayList<>(Arrays.asList(
+                    RUN_TIME,
+                    RUN_ID,
+                    ROLLEDBACK,
+                    RUN_USER,
+                    CLI_ARGS
+            ));
+
+            // a column for each currently-configured output product
+            allOutputProdDefs.forEach(def -> {
+                headers.add(getPreRunProductColNameFor(def));
+                headers.add(getPostRunProductColNameFor(def));
+            });
+
+            this.headers = Collections.unmodifiableList(headers);
+            this.newOutputProductHeadersToEstablishEmptyVersionsFor = new ArrayList<>();
+            this.deconfiguredOutputProductsToTrack = new ArrayList<>();
+        }
+    }
+
+    private List<DeconfiguredOutputProductColPair> determineDeconfiguredProducts(List<OutputProductDefinition<?>> allOutputProdDefs) throws MmtcException {
+        return readExistingHeadersFromFile().stream()
+                .filter(col -> col.startsWith("Latest"))
+                .filter(col -> col.endsWith("Pre-run"))
+                .filter(col -> allOutputProdDefs.stream().noneMatch(def -> col.equals(getPreRunProductColNameFor(def))))
+                .map(col -> new DeconfiguredOutputProductColPair(col, col.replace("Pre", "Post")))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void writeRecord(TableRecord record) throws MmtcException {
+        // modify the record to carry forward values of output product versions that are no longer written
+        TableRecord updatedRec = new TableRecord(record);
+
+        for (DeconfiguredOutputProductColPair deconfiguredOutProdColPair : deconfiguredOutputProductsToTrack) {
+            final String latestProdVersionPreAndPostRun = getLatestNonEmptyValueOfCol(deconfiguredOutProdColPair.postRunColName, RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS).orElse("-");
+            updatedRec.setValue(deconfiguredOutProdColPair.preRunColName, latestProdVersionPreAndPostRun);
+            updatedRec.setValue(deconfiguredOutProdColPair.postRunColName, latestProdVersionPreAndPostRun);
+        }
+
+        super.writeRecord(updatedRec);
     }
 
     public static String getPreRunProductColNameFor(OutputProductDefinition<?> def) {
@@ -76,6 +154,41 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
         return headers;
     }
 
+    public List<DeconfiguredOutputProductColPair> getDeconfiguredOutputProductsToTrack() {
+        return Collections.unmodifiableList(deconfiguredOutputProductsToTrack);
+    }
+
+    private List<String> readExistingHeadersFromFile() throws MmtcException {
+        try {
+            resetParser();
+            final List<String> existingHeaders = parser.getHeaderNames();
+            parser.close();
+            return existingHeaders;
+        } catch (IOException e) {
+            throw new MmtcException(e);
+        }
+    }
+
+    public void updateRowsForNewProducts() throws MmtcException {
+        if (! getFile().exists()) {
+            return;
+        }
+
+        if (newOutputProductHeadersToEstablishEmptyVersionsFor.isEmpty()) {
+            return;
+        }
+
+        logger.info("Updating Run History File with additional columns: " + newOutputProductHeadersToEstablishEmptyVersionsFor);
+        final List<TableRecord> allExistingRecords = readRecords(RollbackEntryOption.INCLUDE_ROLLBACKS);
+        for (TableRecord existingRecord : allExistingRecords) {
+            for (String newHeader : newOutputProductHeadersToEstablishEmptyVersionsFor) {
+                existingRecord.setValue(newHeader, "-");
+            }
+        }
+
+        writeToTableFromTableRecords(allExistingRecords);
+    }
+
     /**
      * Reads the existing RunHistoryFile and returns its contents as a list of TableRecords each representing
      * individual runs. It intentionally ignores any runs previously used in rollback as indicated by the "Rolled Back?"
@@ -86,7 +199,7 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
      */
     public List<TableRecord> readRecords(RollbackEntryOption option) throws MmtcException {
         List<TableRecord> records = new ArrayList<>();
-        if (!this.getFile().exists()) {
+        if (! this.getFile().exists()) {
             return records;
         }
 
@@ -99,7 +212,9 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
             }
 
             for (String column : getHeaders()) {
-                newRecord.setValue(column, record.get(column));
+                if (record.isMapped(column)) {
+                    newRecord.setValue(column, record.get(column));
+                }
             }
             records.add(newRecord);
         }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkKernel.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkKernel.java
@@ -2,7 +2,7 @@ package edu.jhuapl.sd.sig.mmtc.products.model;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
-import edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinition;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 import org.apache.commons.lang3.StringUtils;
@@ -383,7 +383,7 @@ public class SclkKernel extends TextProduct {
      * @throws MmtcException if the SCLK Kernel cannot be written
      * @return the ProductWriteResult describing the newly-written product
      */
-    public static OutputProductDefinition.ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException {
+    public static ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException {
         try {
             final SclkKernel newSclkKernel = new SclkKernel(ctx.currentSclkKernel.get());
 
@@ -405,7 +405,7 @@ public class SclkKernel extends TextProduct {
             final Path path = Paths.get(newSclkKernel.getPath());
             ctx.newSclkKernelPath.set(path);
 
-            return new OutputProductDefinition.ProductWriteResult(
+            return new ProductWriteResult(
                     path,
                     ctx.newSclkVersionString.get()
             );

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkScetFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkScetFile.java
@@ -3,7 +3,7 @@ package edu.jhuapl.sd.sig.mmtc.products.model;
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
 import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationAppConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
-import edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinition;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 
@@ -630,7 +630,7 @@ public class SclkScetFile extends TextProduct {
      * @throws MmtcException if the SCLK-SCET File cannot be written
      * @return a ProductWriteResult describing the updated product
      */
-    public static OutputProductDefinition.ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException {
+    public static ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException {
         final TimeCorrelationAppConfig conf = ctx.config;
 
         try {
@@ -650,7 +650,7 @@ public class SclkScetFile extends TextProduct {
             scetFile.setClockTickRate(ctx.sclk_kernel_fine_tick_modulus.get());
             SclkScet.setScetStrSecondsPrecision(conf.getSclkScetScetUtcPrecision());
 
-            return new OutputProductDefinition.ProductWriteResult(
+            return new ProductWriteResult(
                     scetFile.createNewSclkScetFile(ctx.newSclkKernelPath.get().toString()),
                     ctx.newSclkVersionString.get()
             );

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TableRecord.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TableRecord.java
@@ -14,7 +14,7 @@ import java.util.function.Supplier;
  * the values in the correct order.
  */
 public class TableRecord {
-    private Map<String, String> data;
+    private LinkedHashMap<String, String> data;
 
     /**
      * Create the record and set all values to '-'.
@@ -26,6 +26,14 @@ public class TableRecord {
 
         for (String header : headers) {
             data.put(header, "-");
+        }
+    }
+
+    public TableRecord(TableRecord other) {
+        data = new LinkedHashMap<>();
+
+        for (Map.Entry<String, String> otherData : other.data.entrySet()) {
+            data.put(otherData.getKey(), otherData.getValue());
         }
     }
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
@@ -2,7 +2,7 @@ package edu.jhuapl.sd.sig.mmtc.products.model;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
-import edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinition;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.tlm.FrameSample;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
@@ -125,7 +125,7 @@ public class TimeHistoryFile extends AbstractTimeCorrelationTable {
         return Collections.unmodifiableList(columns);
     }
 
-    public static OutputProductDefinition.ProductWriteResult appendRowFor(TimeCorrelationContext ctx) throws MmtcException {
+    public static ProductWriteResult appendRowFor(TimeCorrelationContext ctx) throws MmtcException {
         final TimeHistoryFile timeHistoryFile = new TimeHistoryFile(ctx.config.getTimeHistoryFilePath(), ctx.config.getTimeHistoryFileExcludeColumns());
         final TableRecord newThfRec = new TableRecord(timeHistoryFile.getHeaders());
 
@@ -135,7 +135,7 @@ public class TimeHistoryFile extends AbstractTimeCorrelationTable {
             throw new MmtcException(e);
         }
 
-        return new OutputProductDefinition.ProductWriteResult(
+        return new ProductWriteResult(
                 timeHistoryFile.getPath(),
                 timeHistoryFile.getLastLineNumber()
         );

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/UplinkCmdFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/UplinkCmdFile.java
@@ -3,7 +3,7 @@ package edu.jhuapl.sd.sig.mmtc.products.model;
 import edu.jhuapl.sd.sig.mmtc.app.MmtcCli;
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
-import edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinition;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 import org.apache.logging.log4j.LogManager;
@@ -54,7 +54,7 @@ public class UplinkCmdFile {
      * @throws MmtcException if the Uplink Command File cannot be written
      * @return a ProductWriteResult describing the newly-written product
      */
-    public static OutputProductDefinition.ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException {
+    public static ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException {
         String cmdFilespec = "";
         try {
             final UplinkCommand uplinkCmd = new UplinkCommand(
@@ -73,7 +73,7 @@ public class UplinkCmdFile {
                     ctx.config.getUplinkCmdFileDir(), cmdFilename
             ).toString());
 
-            return new OutputProductDefinition.ProductWriteResult(
+            return new ProductWriteResult(
                     cmdFile.write(uplinkCmd),
                     Long.toString(ctx.appRunTime.toEpochSecond())
             );

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/rollback/TimeCorrelationRollback.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/rollback/TimeCorrelationRollback.java
@@ -6,15 +6,19 @@ import edu.jhuapl.sd.sig.mmtc.app.MmtcRollbackException;
 import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
 import edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinition;
 import edu.jhuapl.sd.sig.mmtc.products.definition.SclkKernelProductDefinition;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductDirPrefixSuffix;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductLocation;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductPath;
 import edu.jhuapl.sd.sig.mmtc.products.model.RunHistoryFile;
 import edu.jhuapl.sd.sig.mmtc.products.model.TableRecord;
+import edu.jhuapl.sd.sig.mmtc.util.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.FilenameFilter;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -37,7 +41,7 @@ public class TimeCorrelationRollback {
 
     public TimeCorrelationRollback(String... args) throws Exception {
         this.config = new RollbackConfig(args);
-        this.runHistoryFile = new RunHistoryFile(config.getRunHistoryFilePath());
+        this.runHistoryFile = new RunHistoryFile(config.getRunHistoryFilePath(), config.getAllOutputProductDefs());
 
         if (! runHistoryFile.exists()) {
             throw new MmtcRollbackException("Run History File not found; MMTC must have run at least one correlation that is recorded in its Run History File to use rollback.");
@@ -203,7 +207,7 @@ public class TimeCorrelationRollback {
         public static RollbackOperations fromRunHistoryFile(RunHistoryFile runHistoryFile, RollbackConfig config, String newRunIdThatWouldBeCurrentAfterRollback) throws MmtcException {
             List<ProductRollbackOperation<?>> calculatedRollbackOperations = new ArrayList<>();
 
-            for (OutputProductDefinition<?> outputProductDef : OutputProductDefinition.all()) {
+            for (OutputProductDefinition<?> outputProductDef : config.getAllOutputProductDefs()) {
                 String postRunOutputProductColName = RunHistoryFile.getPostRunProductColNameFor(outputProductDef);
 
                 Optional<ProductRollbackOperation<?>> operation = ProductRollbackOperation.calculateFor(
@@ -222,7 +226,7 @@ public class TimeCorrelationRollback {
         public static RollbackOperations toInitialState(RunHistoryFile runHistoryFile, RollbackConfig config) throws MmtcException {
             List<ProductRollbackOperation<?>> calculatedRollbackOperations = new ArrayList<>();
 
-            for (OutputProductDefinition<?> outputProductDef : OutputProductDefinition.all()) {
+            for (OutputProductDefinition<?> outputProductDef : config.getAllOutputProductDefs()) {
                 String preRunOutputProductColName = RunHistoryFile.getPreRunProductColNameFor(outputProductDef);
                 String postRunOutputProductColName = RunHistoryFile.getPostRunProductColNameFor(outputProductDef);
 
@@ -273,7 +277,7 @@ public class TimeCorrelationRollback {
         }
     }
 
-    public static abstract class ProductRollbackOperation<T extends OutputProductDefinition.ResolvedProductLocation> {
+    public static abstract class ProductRollbackOperation<T extends ResolvedProductLocation> {
         public final T configuredDef;
 
         public ProductRollbackOperation(T configuredDef) {
@@ -292,10 +296,10 @@ public class TimeCorrelationRollback {
         public abstract List<String> perform();
     }
 
-    public static class TableTruncationOperation extends ProductRollbackOperation<OutputProductDefinition.ResolvedProductPath> {
+    public static class TableTruncationOperation extends ProductRollbackOperation<ResolvedProductPath> {
         private final String newLatestProductVersion;
 
-        public TableTruncationOperation(OutputProductDefinition.ResolvedProductPath configuredDef, Optional<String> newLatestProductVersion) throws MmtcException {
+        public TableTruncationOperation(ResolvedProductPath configuredDef, Optional<String> newLatestProductVersion) throws MmtcException {
             super(configuredDef);
             this.newLatestProductVersion = newLatestProductVersion.orElseThrow(() -> new MmtcException("A table truncation operation must be given a non-empty row number to truncate the file to"));
 
@@ -309,14 +313,18 @@ public class TimeCorrelationRollback {
             return String.format("%s (%d rows truncated)", configuredDef.pathToProduct.toAbsolutePath(), calcLinesToTruncate());
         }
 
-        public Integer calcLinesToTruncate() {
-            return configuredDef.table.getLastLineNumber() - Integer.parseInt(newLatestProductVersion);
+        public Long calcLinesToTruncate() {
+            try {
+                return FileUtils.countNumLinesInFile(configuredDef.pathToProduct) - Integer.parseInt(newLatestProductVersion);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
 
         @Override
         public List<String> perform() {
             try {String message = String.format("Removed %d lines from %s",
-                    configuredDef.table.truncateRecords(Integer.parseInt(newLatestProductVersion)),
+                    FileUtils.truncateLinesTo(configuredDef.pathToProduct, Integer.parseInt(newLatestProductVersion)),
                     configuredDef.pathToProduct);
                 logger.info(USER_NOTICE, message);
                 return Collections.emptyList();
@@ -327,10 +335,10 @@ public class TimeCorrelationRollback {
         }
     }
 
-    public static class MultiFileDeletionOperation extends ProductRollbackOperation<OutputProductDefinition.ResolvedProductDirAndPrefix> {
+    public static class MultiFileDeletionOperation extends ProductRollbackOperation<ResolvedProductDirPrefixSuffix> {
         private final Optional<String> newLatestProductVersion;
 
-        public MultiFileDeletionOperation(OutputProductDefinition.ResolvedProductDirAndPrefix configuredDef, Optional<String> newLatestProductVersion) throws MmtcException {
+        public MultiFileDeletionOperation(ResolvedProductDirPrefixSuffix configuredDef, Optional<String> newLatestProductVersion) throws MmtcException {
             super(configuredDef);
             this.newLatestProductVersion = newLatestProductVersion;
 
@@ -349,7 +357,7 @@ public class TimeCorrelationRollback {
          */
         public List<File> getOutputProductFilesToDelete() {
             List<File> filesToDelete = new ArrayList<>();
-            FilenameFilter fileFilter = (dir1, name) -> name.startsWith(configuredDef.filenamePrefix);
+            FilenameFilter fileFilter = (dir1, name) -> (name.startsWith(configuredDef.filenamePrefix) && name.endsWith(configuredDef.filenameSuffix));
             File[] foundFiles = configuredDef.containingDirectory.toFile().listFiles(fileFilter);
 
             if (foundFiles == null) {
@@ -392,8 +400,8 @@ public class TimeCorrelationRollback {
         }
     }
 
-    public static class SingleFileDeletionOperation extends ProductRollbackOperation<OutputProductDefinition.ResolvedProductPath> {
-        public SingleFileDeletionOperation(OutputProductDefinition.ResolvedProductPath configuredDef) throws MmtcException {
+    public static class SingleFileDeletionOperation extends ProductRollbackOperation<ResolvedProductPath> {
+        public SingleFileDeletionOperation(ResolvedProductPath configuredDef) throws MmtcException {
             super(configuredDef);
 
             // check to ensure file is present

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/sandbox/MmtcSandboxCreator.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/sandbox/MmtcSandboxCreator.java
@@ -3,8 +3,10 @@ package edu.jhuapl.sd.sig.mmtc.sandbox;
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
 import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.cfg.MmtcSandboxCreatorConfig;
+import edu.jhuapl.sd.sig.mmtc.cfg.PluginProvidedProductConfig;
 import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationXmlPropertiesConfig;
-import edu.jhuapl.sd.sig.mmtc.products.model.SclkKernel;
+import edu.jhuapl.sd.sig.mmtc.products.definition.*;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductDirPrefixSuffix;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,6 +44,8 @@ public class MmtcSandboxCreator {
     private final MmtcConfig originalTkConfig;
 
     private final Path sandboxedMmtcHomeDir;
+    private final Path sandboxedOutputDir;
+    private final Path sandboxedPluginDir;
     private Path sandboxedTkConfDir;
     private Path sandboxedTkConfigPath;
     private Document sandboxedTkConfig;
@@ -54,11 +58,16 @@ public class MmtcSandboxCreator {
 
         this.originalMmtcHomeDir = Paths.get(System.getenv("MMTC_HOME"));
         this.originalTkConfigDir = Paths.get(System.getenv("TK_CONFIG_PATH"));
-        this.originalTkConfig = config; // new TimeCorrelationAppConfig();
+        this.originalTkConfig = config;
 
         this.sandboxedMmtcHomeDir = config.getNewSandboxPath();
+        this.sandboxedPluginDir = sandboxedMmtcHomeDir.resolve(Paths.get("lib", "plugins"));
+        this.sandboxedOutputDir = sandboxedMmtcHomeDir.resolve("output");
     }
 
+    /*
+     * Creates a new sandbox at the configured path.
+     */
     public void create() throws Exception {
         logger.info(USER_NOTICE, String.format("Creating new sandbox at %s", this.sandboxedMmtcHomeDir));
 
@@ -108,6 +117,8 @@ public class MmtcSandboxCreator {
                     sandboxedMmtcHomeDir.resolve(reqdSubDir).toFile()
             );
         }
+
+        Files.createDirectories(sandboxedPluginDir);
     }
 
     private void copyDocsDir() throws IOException {
@@ -143,12 +154,10 @@ public class MmtcSandboxCreator {
         // Telemetry source plugins
         {
             // the plugin copying below handles the fact that the plugin directory may already exist from the above copying of the 'lib' directory
-            final Path newTlmSourcePluginDir = Files.createDirectories(sandboxedMmtcHomeDir.resolve(Paths.get("lib", "plugins")));
-            List<Path> pluginJarsToCopy = Files.list(originalTkConfig.getTelemetrySourcePluginDirectory()).filter(p -> p.startsWith(originalTkConfig.getTelemetrySourcePluginJarPrefix())).collect(Collectors.toList());
-            for (Path pluginJar : pluginJarsToCopy) {
-                Files.copy(pluginJar, newTlmSourcePluginDir.resolve(pluginJar.getFileName()), StandardCopyOption.REPLACE_EXISTING);
+            for (Path pluginJar : findJarsMatching(originalTkConfig.getTelemetrySourcePluginDirectory(), originalTkConfig.getTelemetrySourcePluginJarPrefix())) {
+                Files.copy(pluginJar, sandboxedPluginDir.resolve(pluginJar.getFileName()), StandardCopyOption.REPLACE_EXISTING);
             }
-            setConfigEntryVal(sandboxedTkConfig, "telemetry.source.pluginDirectory", newTlmSourcePluginDir.toString());
+            setConfigEntryVal(sandboxedTkConfig, "telemetry.source.pluginDirectory", sandboxedPluginDir.toString());
 
             Map<String, String> configKeysToUpdate = config.getTelemetrySource().sandboxTelemetrySourceConfiguration(config, sandboxedMmtcHomeDir, sandboxedTkConfDir);
             for (Map.Entry<String, String> updatedKeyVal : configKeysToUpdate.entrySet()) {
@@ -235,31 +244,83 @@ public class MmtcSandboxCreator {
         }
     }
 
-    private void copyOutputs() throws IOException {
-        final Path newOutputDir = sandboxedMmtcHomeDir.resolve("output");
+    private void copyProductsToSandbox(AppendedFileOutputProductDefinition def) throws MmtcException, IOException {
+        final Path originalProductPath = def.resolveLocation(originalTkConfig).pathToProduct.toAbsolutePath();
 
-        // SCLK kernels
-        {
-            final Path originalSclkOutputDir = originalTkConfig.getSclkKernelOutputDir().toAbsolutePath();
-            final Path newSclkOutputDir;
-            if (originalSclkOutputDir.startsWith(originalMmtcHomeDir)) {
-                newSclkOutputDir = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalSclkOutputDir));
+        final Path newProductPath;
+        if (originalProductPath.startsWith(originalMmtcHomeDir)) {
+            newProductPath = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalProductPath));
+        } else {
+            newProductPath = sandboxedOutputDir.resolve(originalProductPath.getFileName());
+        }
+
+        Files.createDirectories(newProductPath.getParent());
+        copyIfExists(
+                originalProductPath,
+                newProductPath
+        );
+
+        updateProductConfig(def.getName(), def.isBuiltIn(), def.getSandboxConfigUpdates(originalTkConfig, newProductPath));
+    }
+
+    private void copyProductsToSandbox(EntireFileOutputProductDefinition def) throws MmtcException, IOException {
+        final ResolvedProductDirPrefixSuffix resolvedDirAndPrefix = def.resolveLocation(originalTkConfig);
+
+        final Path originalProductOutputDir = resolvedDirAndPrefix.containingDirectory;
+        final Path newProductOutputDir;
+        if (originalProductOutputDir.startsWith(originalMmtcHomeDir)) {
+            newProductOutputDir = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalProductOutputDir));
+        } else {
+            newProductOutputDir = sandboxedOutputDir.resolve(def.getName());
+        }
+
+        Files.createDirectories(newProductOutputDir);
+        List<Path> filePathsToCopy = Files.list(originalProductOutputDir)
+                .filter(p -> p.getFileName().toString().startsWith(resolvedDirAndPrefix.filenamePrefix))
+                .filter(p -> p.getFileName().toString().endsWith(resolvedDirAndPrefix.filenameSuffix))
+                .collect(Collectors.toList());
+        for (Path file : filePathsToCopy) {
+            Files.copy(
+                    file,
+                    newProductOutputDir.resolve(file.getFileName())
+            );
+        }
+
+        updateProductConfig(def.getName(), def.isBuiltIn(), def.getSandboxConfigUpdates(originalTkConfig, newProductOutputDir));
+    }
+
+    private void updateProductConfig(String productName, boolean builtIn, Map<String, String> sandboxConfigUpdates) throws MmtcException, IOException {
+        if (builtIn) {
+            // query for updated config, and apply them without restriction
+            sandboxConfigUpdates.forEach((k, v) -> setConfigEntryVal(sandboxedTkConfig, k, v));
+        } else {
+            // copy output plugin jar to the new lib/plugin directory
+            final PluginProvidedProductConfig originalPluginConfig = PluginProvidedProductConfig.createFrom(originalTkConfig, productName);
+
+            for (Path pluginJar : findJarsMatching(originalPluginConfig.pluginDir, originalPluginConfig.pluginJarPrefix)) {
+                Files.copy(pluginJar, sandboxedPluginDir.resolve(pluginJar.getFileName()), StandardCopyOption.REPLACE_EXISTING);
+            }
+            setConfigEntryVal(sandboxedTkConfig, String.format("product.plugin.%s.pluginDirectory", productName), sandboxedPluginDir.toAbsolutePath().toString());
+
+            // query for updated config, and apply them limited to their own key namespace
+            sandboxConfigUpdates.forEach((k, v) -> {
+                if (!k.startsWith(String.format("product.plugin.%s.config.", productName))) {
+                    throw new IllegalArgumentException("Plugin may not update config key: " + k);
+                }
+                setConfigEntryVal(sandboxedTkConfig, k, v);
+            });
+        }
+    }
+
+    private void copyOutputs() throws IOException, MmtcException {
+        for (OutputProductDefinition<?> def : originalTkConfig.getAllOutputProductDefs()) {
+            if (def instanceof AppendedFileOutputProductDefinition) {
+                copyProductsToSandbox((AppendedFileOutputProductDefinition) def);
+            } else if (def instanceof EntireFileOutputProductDefinition) {
+                copyProductsToSandbox((EntireFileOutputProductDefinition) def);
             } else {
-                newSclkOutputDir = newOutputDir.resolve("sclk");
+                throw new IllegalStateException("An OutputProductDefinition must inherit from either AppendedFileOutputProductDefintion or EntireFileOutputProductDefinition");
             }
-
-            Files.createDirectories(newSclkOutputDir);
-            List<Path> sclkKernelsToCopy = Files.list(originalSclkOutputDir)
-                    .filter(p -> p.getFileName().toString().startsWith(originalTkConfig.getSclkKernelBasename()))
-                    .filter(p -> p.getFileName().toString().endsWith(SclkKernel.FILE_SUFFIX))
-                    .collect(Collectors.toList());
-            for (Path sclkKernel : sclkKernelsToCopy) {
-                Files.copy(
-                        sclkKernel,
-                        newSclkOutputDir.resolve(sclkKernel.getFileName())
-                );
-            }
-            setConfigEntryVal(sandboxedTkConfig, "spice.kernel.sclk.kerneldir", newSclkOutputDir.toString());
         }
 
         // Run History file
@@ -268,7 +329,7 @@ public class MmtcSandboxCreator {
             if (originalTkConfig.getRunHistoryFilePath().startsWith(originalMmtcHomeDir)) {
                 newRunHistoryFilePath = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalTkConfig.getRunHistoryFilePath()));
             } else {
-                newRunHistoryFilePath = newOutputDir.resolve(originalTkConfig.getRunHistoryFilePath().getFileName());
+                newRunHistoryFilePath = sandboxedOutputDir.resolve(originalTkConfig.getRunHistoryFilePath().getFileName());
             }
 
             Files.createDirectories(newRunHistoryFilePath.getParent());
@@ -277,93 +338,6 @@ public class MmtcSandboxCreator {
                     newRunHistoryFilePath
             );
             setConfigEntryVal(sandboxedTkConfig, "table.runHistoryFile.path", newRunHistoryFilePath.toString());
-        }
-
-        // Raw Telemetry Table
-        {
-            final Path newRawTelemetryTablePath;
-            if (originalTkConfig.getRawTelemetryTablePath().startsWith(originalMmtcHomeDir)) {
-                newRawTelemetryTablePath = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalTkConfig.getRawTelemetryTablePath()));
-            } else {
-                newRawTelemetryTablePath = newOutputDir.resolve(originalTkConfig.getRawTelemetryTablePath().getFileName());
-            }
-
-            Files.createDirectories(newRawTelemetryTablePath.getParent());
-            copyIfExists(
-                    originalTkConfig.getRawTelemetryTablePath(),
-                    newRawTelemetryTablePath
-            );
-            setConfigEntryVal(sandboxedTkConfig, "table.rawTelemetryTable.path", newRawTelemetryTablePath.toString());
-        }
-
-        // Time History File
-        {
-            final Path newTimeHistoryFilePath;
-            if (originalTkConfig.getTimeHistoryFilePath().startsWith(originalMmtcHomeDir)) {
-                newTimeHistoryFilePath = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalTkConfig.getTimeHistoryFilePath()));
-            } else {
-                newTimeHistoryFilePath = newOutputDir.resolve(originalTkConfig.getTimeHistoryFilePath().getFileName());
-            }
-
-            Files.createDirectories(newTimeHistoryFilePath.getParent());
-            copyIfExists(
-                    originalTkConfig.getTimeHistoryFilePath(),
-                    newTimeHistoryFilePath
-            );
-            setConfigEntryVal(sandboxedTkConfig, "table.timeHistoryFile.path", newTimeHistoryFilePath.toString());
-        }
-
-        // SCLK-SCET files
-        {
-            // todo change this to see if any sclk-scet files have ever been produced
-            if (originalTkConfig.createSclkScetFile()) {
-                final Path originalSclkScetOutputDir = originalTkConfig.getSclkScetOutputDir().toAbsolutePath();
-                final Path newSclkScetOutputDir;
-                if (originalSclkScetOutputDir.startsWith(originalMmtcHomeDir)) {
-                    newSclkScetOutputDir = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalSclkScetOutputDir));
-                } else {
-                    newSclkScetOutputDir = newOutputDir.resolve("sclkscet");
-                }
-
-                Files.createDirectories(newSclkScetOutputDir);
-                List<Path> sclkScetFilesToCopy = Files.list(originalSclkScetOutputDir)
-                        .filter(p -> p.getFileName().toString().startsWith(originalTkConfig.getSclkScetFileBasename()))
-                        .filter(p -> p.getFileName().toString().endsWith(originalTkConfig.getSclkScetFileSuffix()))
-                        .collect(Collectors.toList());
-                for (Path sclkScetFile : sclkScetFilesToCopy) {
-                    Files.copy(
-                            sclkScetFile,
-                            newSclkScetOutputDir.resolve(sclkScetFile.getFileName())
-                    );
-                }
-                setConfigEntryVal(sandboxedTkConfig, "product.sclkScetFile.dir", newSclkScetOutputDir.toString());
-            }
-        }
-
-        // uplink cmd files
-        {
-            // todo change this to see if any uplink command files have ever been produced
-            if (originalTkConfig.containsKey("product.uplinkCmdFile.outputDir")) {
-                final Path originalUplinkCmdFileOutputDir = Paths.get(originalTkConfig.getUplinkCmdFileDir()).toAbsolutePath();
-                final Path newUplinkCmdFileOutputDir;
-                if (originalUplinkCmdFileOutputDir.startsWith(originalMmtcHomeDir)) {
-                    newUplinkCmdFileOutputDir = sandboxedMmtcHomeDir.resolve(originalMmtcHomeDir.relativize(originalUplinkCmdFileOutputDir));
-                } else {
-                    newUplinkCmdFileOutputDir = newOutputDir.resolve("uplinkCmd");
-                }
-
-                Files.createDirectories(newUplinkCmdFileOutputDir);
-                List<Path> uplinkCmdFilesToCopy = Files.list(originalUplinkCmdFileOutputDir)
-                        .filter(p -> p.getFileName().toString().startsWith(originalTkConfig.getUplinkCmdFileBasename()))
-                        .collect(Collectors.toList());
-                for (Path uplinkCmdFile : uplinkCmdFilesToCopy) {
-                    Files.copy(
-                            uplinkCmdFile,
-                            newUplinkCmdFileOutputDir.resolve(uplinkCmdFile.getFileName())
-                    );
-                }
-                setConfigEntryVal(sandboxedTkConfig, "product.uplinkCmdFile.outputDir", newUplinkCmdFileOutputDir.toString());
-            }
         }
     }
 
@@ -428,5 +402,9 @@ public class MmtcSandboxCreator {
         } catch (TransformerException e) {
             throw new IOException(e);
         }
+    }
+
+    private static List<Path> findJarsMatching(Path containingDir, String jarPrefix) throws IOException {
+        return Files.list(containingDir).filter(p -> p.startsWith(jarPrefix)).collect(Collectors.toList());
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/tlm/TelemetrySource.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/tlm/TelemetrySource.java
@@ -46,8 +46,9 @@ public interface TelemetrySource {
     /**
      * This method is called when MMTC configuration has been fully initialized and validated, and provides a chance for
      * TelemetrySource implementations to save a reference to the entire MMTC TimeCorrelationAppConfig instance or parts
-     * therein.  It also provides an opportunity for TelemetrySource implementations to perform their own validation
-     * before continuing.  A thrown MmtcException from this method will log the issue and prevent further processing.
+     * therein.  It also provides an opportunity for TelemetrySource implementations to perform their own initialization or
+     * configuration validation before continuing.  A thrown MmtcException from this method will log the issue and
+     * prevent further time correlation processing.
      * <p>
      * For instance, an implementation should likely check whether the enabled set of MMTC filters is compatible with
      * the telemetry that the TelemetrySource implementation can provide.  If an incompatible filter is enabled, the

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/util/FileUtils.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/util/FileUtils.java
@@ -1,11 +1,17 @@
 package edu.jhuapl.sd.sig.mmtc.util;
 
+import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class FileUtils {
     private static final Logger logger = LogManager.getLogger();
@@ -41,5 +47,38 @@ public class FileUtils {
 
     public static boolean fileExistsAndIsWritable(Path p) {
         return Files.exists(p) && Files.isWritable(p);
+    }
+
+    public static Path findUniqueJarFileWithinDir(Path containingDir, String jarPrefix) throws IOException, MmtcException {
+        try (Stream<Path> files = Files.list(containingDir)) {
+            List<Path> results = files.filter(p -> p.toString().endsWith(".jar"))
+                    .filter(p -> p.getFileName().toString().startsWith(jarPrefix))
+                    .collect(Collectors.toList());
+
+            if (results.size() != 1) {
+                throw new MmtcException(String.format("A unique plugin jar was not found at the given location: %d matching jars found at %s", results.size(), containingDir));
+            }
+
+            return results.get(0);
+        }
+    }
+
+    public static Long countNumLinesInFile(Path path) throws IOException {
+        try (Stream<String> lineStream = Files.lines(path)) {
+            return lineStream.count();
+        }
+    }
+
+    public static Integer truncateLinesTo(Path pathToProduct, int linesRemainingAfterTruncation) throws IOException {
+        final List<String> allOriginalLines = Files.readAllLines(pathToProduct);
+        final List<String> linesToKeep = allOriginalLines.subList(0, linesRemainingAfterTruncation);
+
+        // all MMTC output products that are appended to currently end with a newline, which is POSIX convention
+        Files.write(
+                pathToProduct,
+                (String.join("\n", linesToKeep) + "\n").getBytes(StandardCharsets.UTF_8)
+        );
+
+        return allOriginalLines.size() - linesToKeep.size();
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/util/Owlt.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/util/Owlt.java
@@ -44,7 +44,7 @@ public class Owlt {
      * @return true if the SPICE library has already been loaded
      */
     public static boolean isInitialized() {
-        return TimeConvert.spiceLibLoaded() & TimeConvert.kernelsLoaded();
+        return TimeConvert.spiceLibLoaded() && TimeConvert.kernelsLoaded();
     }
 
 

--- a/mmtc-core/src/main/resources/META-INF/services/edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinitionFactory
+++ b/mmtc-core/src/main/resources/META-INF/services/edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinitionFactory
@@ -1,0 +1,1 @@
+edu.jhuapl.sd.sig.mmtc.products.definition.BuiltInOutputProductDefinitionFactory

--- a/mmtc-core/src/main/resources/TimeCorrelationConfigProperties.xsd
+++ b/mmtc-core/src/main/resources/TimeCorrelationConfigProperties.xsd
@@ -9,7 +9,7 @@
 
   <xs:simpleType name="pluginEntryKey">
     <xs:restriction base="xs:string">
-      <xs:pattern value="telemetry\.source\.config\..+"/>
+      <xs:pattern value="(telemetry\.source\.config\..+)|(product\.plugin\..+)"/>
     </xs:restriction>
   </xs:simpleType>
 
@@ -133,6 +133,7 @@
       <xs:enumeration value="table.timeHistoryFile.path"/>
       <xs:enumeration value="table.timeHistoryFile.excludeColumns"/>
       <xs:enumeration value="table.timeHistoryFile.scetUtcPrecision"/>
+
       <xs:enumeration value="product.sclkScetFile.create"/>
       <xs:enumeration value="product.sclkScetFile.dir"/>
       <xs:enumeration value="product.sclkScetFile.baseName"/>
@@ -146,6 +147,8 @@
       <xs:enumeration value="product.uplinkCmdFile.create"/>
       <xs:enumeration value="product.uplinkCmdFile.outputDir"/>
       <xs:enumeration value="product.uplinkCmdFile.baseName"/>
+
+      <xs:enumeration value="product.plugin.outputProductNames"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="entryKey">

--- a/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/table/RunHistoryFileTests.java
+++ b/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/table/RunHistoryFileTests.java
@@ -1,6 +1,8 @@
 package edu.jhuapl.sd.sig.mmtc.table;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
+import edu.jhuapl.sd.sig.mmtc.products.definition.BuiltInOutputProductDefinitionFactory;
+import edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinition;
 import edu.jhuapl.sd.sig.mmtc.products.model.RunHistoryFile;
 import edu.jhuapl.sd.sig.mmtc.products.model.TableRecord;
 import org.junit.jupiter.api.Test;
@@ -9,15 +11,18 @@ import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class RunHistoryFileTests {
+    // a shortcut to get just the basic built-in product defs
+    private static final List<OutputProductDefinition<?>> BUILTIN_DEFS = new BuiltInOutputProductDefinitionFactory().getApplicableTypes().stream().map(t -> new BuiltInOutputProductDefinitionFactory().create(t, null, null)).collect(Collectors.toList());
 
     @Test
-    public void testRunHistoryFileBasicRead() throws URISyntaxException, MmtcException {
+    public void testRunHistoryFileBasicRead() throws MmtcException {
         // with no rollbacks, with every column at least partially populated
-        final RunHistoryFile runHistoryFile = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh.csv"));
+        final RunHistoryFile runHistoryFile = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh.csv"), BUILTIN_DEFS);
         assertEquals(4, runHistoryFile.readRecords(RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS).size());
         assertEquals(4, runHistoryFile.readRecords(RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS).size());
 
@@ -29,7 +34,7 @@ public class RunHistoryFileTests {
         assertEquals("1734040773", lastRec.getValue("Latest Uplink Command File Post-run"));
 
         // with no rollbacks, with the uplink cmd file columns not populated
-        final RunHistoryFile runHistoryFileNoUplink = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-no-uplink.csv"));
+        final RunHistoryFile runHistoryFileNoUplink = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-no-uplink.csv"), BUILTIN_DEFS);
         assertEquals(4, runHistoryFileNoUplink.readRecords(RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS).size());
         assertEquals(4, runHistoryFileNoUplink.readRecords(RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS).size());
 
@@ -41,7 +46,7 @@ public class RunHistoryFileTests {
         assertEquals("-", lastRec.getValue("Latest Uplink Command File Post-run"));
 
         // with a rollback
-        final RunHistoryFile runHistoryFileRollback = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-rollback.csv"));
+        final RunHistoryFile runHistoryFileRollback = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-rollback.csv"), BUILTIN_DEFS);
         assertEquals(6, runHistoryFileRollback.readRecords(RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS).size());
         assertEquals(4, runHistoryFileRollback.readRecords(RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS).size());
 
@@ -56,20 +61,20 @@ public class RunHistoryFileTests {
     @Test
     public void testRunHistoryFileValueQueries() throws URISyntaxException, MmtcException {
         // with no rollbacks, with every column at least partially populated
-        final RunHistoryFile runHistoryFile = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh.csv"));
+        final RunHistoryFile runHistoryFile = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh.csv"), BUILTIN_DEFS);
         assertEquals(Optional.of("1734040773"), runHistoryFile.getLatestNonEmptyValueOfCol("Latest Uplink Command File Post-run", RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS));
         assertTrue(runHistoryFile.anyValuesInColumn("Latest Uplink Command File Post-run"));
         assertEquals(Optional.of("1002"), runHistoryFile.getValueOfColForRun("00002", "Latest SCLK Kernel Post-run"));
         assertEquals(Optional.of("1004"), runHistoryFile.getLatestNonEmptyValueOfCol("Latest SCLK Kernel Post-run", RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS));
 
         // with no rollbacks, with the uplink cmd file columns not populated
-        final RunHistoryFile runHistoryFileNoUplink = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-no-uplink.csv"));
+        final RunHistoryFile runHistoryFileNoUplink = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-no-uplink.csv"), BUILTIN_DEFS);
         assertEquals(Optional.empty(), runHistoryFileNoUplink.getLatestNonEmptyValueOfCol("Latest Uplink Command File Post-run", RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS));
         assertEquals(Optional.empty(), runHistoryFileNoUplink.getLatestValueOfCol("Latest Uplink Command File Post-run", RunHistoryFile.RollbackEntryOption.INCLUDE_ROLLBACKS));
         assertFalse(runHistoryFileNoUplink.anyValuesInColumn("Latest Uplink Command File Post-run"));
 
         // with a rollback
-        final RunHistoryFile runHistoryFileRollback = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-rollback.csv"));
+        final RunHistoryFile runHistoryFileRollback = new RunHistoryFile(Paths.get("src/test/resources/RunHistoryFileTests/RunHistoryFile-nh-rollback.csv"), BUILTIN_DEFS);
         assertEquals(Optional.of("1753199537"), runHistoryFileRollback.getLatestNonEmptyValueOfCol("Latest Uplink Command File Post-run", RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS));
         assertEquals(Optional.of("1753199537"), runHistoryFileRollback.getLatestValueOfCol("Latest Uplink Command File Post-run", RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS));
         assertTrue(runHistoryFileRollback.anyValuesInColumn("Latest Uplink Command File Post-run"));

--- a/mmtc-output-plugin-sdk/build.gradle.kts
+++ b/mmtc-output-plugin-sdk/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     testImplementation(testlibs.mockito.inline)
 }
 
-description = "mmtc-tlm-plugin-example"
+description = "mmtc-output-plugin-example"
 
 java {
     withJavadocJar()

--- a/mmtc-output-plugin-sdk/create-sdk-zip.sh
+++ b/mmtc-output-plugin-sdk/create-sdk-zip.sh
@@ -41,4 +41,4 @@ cp -r ../gradlew                                                    $SDK_DIR
 cp -r ../gradle                                                     $SDK_DIR
 
 cd $SDK_DIR
-zip -qr ../mmtc-$1-tlm-source-plugin-sdk.zip                         .
+zip -qr ../mmtc-$1-output-plugin-sdk.zip                         .

--- a/mmtc-output-plugin-sdk/etc/build.gradle.kts
+++ b/mmtc-output-plugin-sdk/etc/build.gradle.kts
@@ -1,26 +1,47 @@
 import java.time.Instant
 
 plugins {
-    id("java-conventions")
+    `java-library`
+}
+
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+tasks.withType<JavaCompile>() {
+    options.encoding = "UTF-8"
+}
+
+tasks.withType<Javadoc>() {
+    options.encoding = "UTF-8"
+}
+
+repositories {
+    maven {
+        url = uri("file://${project.rootProject.projectDir}/lib/")
+    }
+
+    maven {
+        url = uri("https://repo.maven.apache.org/maven2/")
+    }
 }
 
 dependencies {
-    compileOnly(project(":mmtc-core"))
+    compileOnly("edu.jhuapl.sd.sig:mmtc-core:@VERSION@")
 
     implementation(libs.commons.cli)
     implementation(libs.log4j.api)
     implementation(libs.log4j.core)
     implementation(libs.log4j.jcl)
 
-    testImplementation(project(":mmtc-core"))
+    testImplementation(files("lib/mmtc-core-@VERSION@.jar"))
     testImplementation(testlibs.junit.jupiter.api)
     testImplementation(testlibs.junit.jupiter.params)
     testImplementation(testlibs.junit.jupiter.engine)
-    testRuntimeOnly(testlibs.junit.platform.launcher)
     testImplementation(testlibs.mockito.inline)
 }
 
-description = "mmtc-tlm-plugin-example"
+group = "edu.jhuapl.sd.sig"
+version = "1.0.0-SNAPSHOT"
+description = "mmtc-output-plugin-example"
 
 java {
     withJavadocJar()
@@ -41,22 +62,4 @@ tasks.jar {
             "Implementation-Version" to project.version
         )
     }
-}
-
-val createSdkDist = tasks.register("createSdkDist") {
-    inputs.dir("src/main")
-    inputs.file("create-sdk-zip.sh")
-
-    dependsOn(":mmtc-core:jar")
-    dependsOn(":userGuidePdf")
-    dependsOn(":mmtc-core:generatePomFileForMmtc-corePublication")
-
-    doLast {
-        exec {
-            workingDir(project.projectDir)
-            commandLine("bash", "create-sdk-zip.sh", project.version)
-        }
-    }
-
-    outputs.dir("build/mmtc-sdk-tmp")
 }

--- a/mmtc-output-plugin-sdk/etc/settings.gradle.kts
+++ b/mmtc-output-plugin-sdk/etc/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "mmtc-tlm-plugin-example"
+rootProject.name = "mmtc-output-plugin-example"
 
 dependencyResolutionManagement {
     versionCatalogs {

--- a/mmtc-output-plugin-sdk/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/ExampleAppendedFileOutputProductDefinition.java
+++ b/mmtc-output-plugin-sdk/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/ExampleAppendedFileOutputProductDefinition.java
@@ -1,0 +1,66 @@
+package edu.jhuapl.sd.sig.mmtc.products.definition;
+
+import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
+import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductPath;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.Map;
+
+public class ExampleAppendedFileOutputProductDefinition extends AppendedFileOutputProductDefinition {
+    private static final String FILENAME = "Example-Appended-File.csv";
+    private static final Path HARDCODED_OUTPUT_PATH = Paths.get(System.getenv("MMTC_HOME"), "output", FILENAME);
+    private static final String HEADER = "Run ID,SCLK Version,Predicted Clock Change Rate";
+
+    private final Map<String, String> config;
+
+    public ExampleAppendedFileOutputProductDefinition(String name, Map<String, String> config) {
+        super(name);
+        this.config = Collections.unmodifiableMap(config);
+    }
+
+    @Override
+    public ProductWriteResult appendToProduct(TimeCorrelationContext ctx) throws MmtcException {
+        try {
+            if (! Files.exists(HARDCODED_OUTPUT_PATH)) {
+                Files.write(HARDCODED_OUTPUT_PATH, (HEADER + "\n").getBytes(StandardCharsets.UTF_8));
+            }
+
+            Files.write(
+                    HARDCODED_OUTPUT_PATH,
+                    String.format("%d,%s,%.11f\n", ctx.runId.get(), ctx.newSclkVersionString.get(), ctx.correlation.predicted_clock_change_rate.get()).getBytes(StandardCharsets.UTF_8),
+                    StandardOpenOption.APPEND
+            );
+
+            return new ProductWriteResult(
+                    HARDCODED_OUTPUT_PATH,
+                    Files.readAllLines(HARDCODED_OUTPUT_PATH).size()
+            );
+        } catch (IOException e) {
+            throw new MmtcException(e);
+        }
+    }
+
+    @Override
+    public ResolvedProductPath resolveLocation(MmtcConfig config) {
+        return new ResolvedProductPath(HARDCODED_OUTPUT_PATH);
+    }
+
+    @Override
+    public boolean shouldBeWritten(TimeCorrelationContext ctx) {
+        return true;
+    }
+
+    @Override
+    public Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputPath) {
+        return Collections.emptyMap();
+    }
+}

--- a/mmtc-output-plugin-sdk/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/ExampleEntireFileOutputProductDefinition.java
+++ b/mmtc-output-plugin-sdk/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/ExampleEntireFileOutputProductDefinition.java
@@ -1,0 +1,76 @@
+package edu.jhuapl.sd.sig.mmtc.products.definition;
+
+import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
+import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductDirPrefixSuffix;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+
+public class ExampleEntireFileOutputProductDefinition extends EntireFileOutputProductDefinition {
+    private static final Logger logger = LogManager.getLogger();
+
+    private static final String FILE_PREFIX = "Example-Entire-File_";
+    private static final String FILE_SUFFIX = ".txt";
+    private final Map<String, String> config;
+
+    public ExampleEntireFileOutputProductDefinition(String name, Map<String, String> config) {
+        super(name);
+        this.config = Collections.unmodifiableMap(config);
+    }
+
+    @Override
+    public ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException {
+        final Path outputPath = Paths.get(System.getenv("MMTC_HOME"), "output", FILE_PREFIX + ctx.newSclkVersionString.get() + FILE_SUFFIX);
+
+        logger.info(config);
+
+        final String contents = new StringBuilder()
+                .append("Header: " + config.getOrDefault("customHeaderContent", "Default Header Content"))
+                .append("\n")
+                .append("Predicted clock change rate: ")
+                .append(ctx.correlation.predicted_clock_change_rate.get())
+                .append("\n")
+                .append("Footer: " + config.getOrDefault("customFooterContent", "Default Footer Content"))
+                .toString();
+
+        try {
+            Files.write(
+                    outputPath,
+                    contents.getBytes(StandardCharsets.UTF_8)
+            );
+        } catch (IOException e) {
+            throw new MmtcException(e);
+        }
+
+        return new ProductWriteResult(outputPath, ctx.newSclkVersionString.get());
+    }
+
+    @Override
+    public ResolvedProductDirPrefixSuffix resolveLocation(MmtcConfig config) throws MmtcException {
+        return new ResolvedProductDirPrefixSuffix(
+                Paths.get(System.getenv("MMTC_HOME"), "output"),
+                FILE_PREFIX,
+                FILE_SUFFIX
+        );
+    }
+
+    @Override
+    public boolean shouldBeWritten(TimeCorrelationContext ctx) {
+        return true;
+    }
+
+    @Override
+    public Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputDir) {
+        return Collections.emptyMap();
+    }
+}

--- a/mmtc-output-plugin-sdk/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/ExampleOutputProductDefinitionFactory.java
+++ b/mmtc-output-plugin-sdk/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/ExampleOutputProductDefinitionFactory.java
@@ -1,0 +1,24 @@
+package edu.jhuapl.sd.sig.mmtc.products.definition;
+
+import java.util.*;
+
+public class ExampleOutputProductDefinitionFactory implements OutputProductDefinitionFactory {
+    private static final String EXAMPLE_ENTIRE_FILE_TYPE = "Example Entire File Product";
+    private static final String EXAMPLE_APPENDED_FILE_TYPE = "Example Appended File Product";
+
+    @Override
+    public List<String> getApplicableTypes() {
+        return Arrays.asList(EXAMPLE_ENTIRE_FILE_TYPE, EXAMPLE_APPENDED_FILE_TYPE);
+    }
+
+    @Override
+    public OutputProductDefinition<?> create(String type, String name, Map<String, String> config) {
+        if (type.equals(EXAMPLE_ENTIRE_FILE_TYPE)) {
+            return new ExampleEntireFileOutputProductDefinition(name, config);
+        } else if (type.equals(EXAMPLE_APPENDED_FILE_TYPE)) {
+            return new ExampleAppendedFileOutputProductDefinition(name, config);
+        } else {
+            throw new IllegalArgumentException("Can't create product of type: " + type);
+        }
+    }
+}

--- a/mmtc-output-plugin-sdk/src/main/resources/META-INF/services/edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinitionFactory
+++ b/mmtc-output-plugin-sdk/src/main/resources/META-INF/services/edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinitionFactory
@@ -1,0 +1,1 @@
+edu.jhuapl.sd.sig.mmtc.products.definition.ExampleOutputProductDefinitionFactory

--- a/mmtc-tlm-source-plugin-sdk/etc/build.gradle.kts
+++ b/mmtc-tlm-source-plugin-sdk/etc/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
 
 group = "edu.jhuapl.sd.sig"
 version = "1.0.0-SNAPSHOT"
-description = "mmtc-plugin-example"
+description = "mmtc-tlm-plugin-example"
 
 java {
     withJavadocJar()


### PR DESCRIPTION
Add functionality to MMTC for adaptations to declare one or many custom output products, implemented by external jars (compiled against mmtc-core) that implements the `OutputProductDefinitionFactory` interface.  These output product implementations:
- must be defined as `OutputProductDefinitions` that extend either `AppendedFileOutputProductDefinition` or `EntireFileOutputProductDefinition`
- are written last in a correlation run, and are included in the Run History, rollback, and sandboxing functionality
- are provided a `TimeCorrelationContext` from which to pull information about the current or past correlations

Also:
- Adds an output product plugin SDK, containing an example Gradle project with functional example implementations to serve as the base for custom plugins
- Allows the default Time History File product to be disabled
- Updates User Guide with new section and information on custom output products