### PR TITLE
Add new "dry run" CLI option

### DIFF
--- a/docs/MMTC_Users_Guide.adoc
+++ b/docs/MMTC_Users_Guide.adoc
@@ -662,6 +662,13 @@ This option and any other *--clkchgrate-** options are mutually exclusive.
 |N/A
 |In a testing environment and in certain operational scenarios, it can be necessary to have MMTC assign the clock change rate of the new time correlation to 1.0, indicating no clock drift, rather than computing it. Also, if this option is selected,  MMTC will not replace the existing clock change rate in the SCLK kernel with an interpolated value. The value 1.00000000000 will appear in the new (latest) time correlation record in the SCLK kernel and SCLK/SCET file. This option and any other *--clkchgrate-** options are mutually exclusive.
 
+|-D
+|--dry-run
+|N/A
+|Runs MMTC in dry run mode. No output products will be modified or created and "what-if" output
+products will instead be printed to the console and written to the log. The run history file will likewise
+remain unappended. Otherwise runs MMTC normally according to other options and config keys.
+
 |-F
 |--disable-contact-filter
 |N/A

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/TimeCorrelationApp.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/TimeCorrelationApp.java
@@ -26,6 +26,7 @@ import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
 
 import static edu.jhuapl.sd.sig.mmtc.app.MmtcCli.USER_NOTICE;
 
@@ -384,7 +385,7 @@ public class TimeCorrelationApp {
             logger.warn(String.format("Test mode is enabled! One-way light time will be set to the provided value %f and ancillary positional and velocity calculations will be skipped.", config.getTestModeOwlt()));
         }
         if (config.isDryRun()) {
-            logger.warn("Dry run mode is enabled! No data products from this run will be kept and will instead be printed to the console and recorded in the log at {}/log/", System.getenv("MMTC_HOME"));
+            logger.warn("Dry run mode is enabled! No data products from this run will be kept and will instead be printed to the console and recorded in the log file according to log4j2.xml");
         }
 
 
@@ -514,9 +515,6 @@ public class TimeCorrelationApp {
             runHistoryFile.writeRecord(newRunHistoryFileRecord);
             logger.info(USER_NOTICE, "Appended a new entry to Run History File located at " + runHistoryFile.getPath());
             logger.info(String.format("Run at %s recorded to %s", ctx.appRunTime, config.getRunHistoryFilePath().toString()));
-        } else {
-            Files.deleteIfExists(ctx.newSclkKernelPath.get());
-            logger.info(USER_NOTICE, "Deleted temporary SCLK kernel {}. No other output products were written to disk.", ctx.newSclkKernelPath.get());
         }
 
         logger.info(USER_NOTICE, "MMTC completed successfully.");

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/CorrelationCommandLineConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/CorrelationCommandLineConfig.java
@@ -96,8 +96,7 @@ public class CorrelationCommandLineConfig implements IConfiguration {
                 "D",
                 "dry-run",
                 false,
-                "Executes a dry run of MMTC with outputs calculated as otherwise configured " +
-                        "but only records them in the log without writing/modifying product files."
+                "Enables dry-run mode, resulting in correlation outputs being printed & logged but not written to the filesystem. The run history file likewise won't be modified."
         );
 
         opts.addOption("h", "help", false, "Print this message.");

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/CorrelationCommandLineConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/CorrelationCommandLineConfig.java
@@ -92,6 +92,14 @@ public class CorrelationCommandLineConfig implements IConfiguration {
                 "Run in test mode, which allows the user to override one-way-light-time."
         );
 
+        opts.addOption(
+                "D",
+                "dry-run",
+                false,
+                "Executes a dry run of MMTC with outputs calculated as otherwise configured " +
+                        "but only records them in the log without writing/modifying product files."
+        );
+
         opts.addOption("h", "help", false, "Print this message.");
 
         for (Option additionalOption : additionalOptions) {
@@ -174,6 +182,10 @@ public class CorrelationCommandLineConfig implements IConfiguration {
 
     boolean isTestMode() {
         return cmdLine.hasOption("T") || cmdLine.hasOption("test-mode-owlt");
+    }
+
+    boolean isDryRun() {
+        return cmdLine.hasOption("D") || cmdLine.hasOption("dry-run");
     }
 
     double getTestModeOwlt() {

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/TimeCorrelationAppConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/TimeCorrelationAppConfig.java
@@ -281,6 +281,15 @@ public class TimeCorrelationAppConfig extends MmtcConfig{
     }
 
     /**
+     * Indicates if this is a dry run
+     *
+     * @return true if -D or --dry-run CLI options are invoked
+     */
+    public boolean isDryRun() {
+        return cmdLineConfig.isDryRun();
+    }
+
+    /**
      * Indicates if an optional Uplink Command File is to be created. This can be specified in either the command line
      * or in configuration parameters. Command line overrides the configuration parameter.
      *

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/correlation/TimeCorrelationContext.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/correlation/TimeCorrelationContext.java
@@ -23,6 +23,7 @@ public class TimeCorrelationContext {
     public final Settable<Integer> runId = new Settable<>();
 
     public final Settable<SclkKernel> currentSclkKernel = new Settable<>();
+    public final Settable<SclkKernel> newSclkKernel = new Settable<>();
     public final Settable<String> newSclkVersionString = new Settable<>();
     public final Settable<Path> newSclkKernelPath = new Settable<>();
     public final Settable<Integer> tk_sclk_fine_tick_modulus = new Settable<>();

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/OutputProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/OutputProductDefinition.java
@@ -6,9 +6,12 @@ import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductLocation;
+import edu.jhuapl.sd.sig.mmtc.products.model.TextProductException;
 import edu.jhuapl.sd.sig.mmtc.rollback.TimeCorrelationRollback;
 import edu.jhuapl.sd.sig.mmtc.util.Settable;
+import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
@@ -58,6 +61,19 @@ public abstract class OutputProductDefinition<T extends ResolvedProductLocation>
      * @return true if the product should be written, false otherwise
      */
     public abstract boolean shouldBeWritten(TimeCorrelationContext context);
+
+    /**
+     * Generates a string summarizing the hypothetical changes to an output product that would have been made had this been a real
+     * run and the dry run flag wasn't passed. This generally involves all the steps usually taken to compute and produce an MMTC
+     * output product except actually writing it to disk (except the SCLK kernel which must be written but will later be deleted).
+     * @param ctx
+     * @return
+     * @throws MmtcException
+     * @throws TextProductException
+     * @throws IOException
+     * @throws TimeConvertException
+     */
+    public abstract String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException, TextProductException, IOException, TimeConvertException;
 
     /**
      * Write the product to the filesystem.  Called once per successful time correlation run.

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/OutputProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/OutputProductDefinition.java
@@ -1,83 +1,93 @@
 package edu.jhuapl.sd.sig.mmtc.products.definition;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
-import edu.jhuapl.sd.sig.mmtc.products.model.AbstractTimeCorrelationTable;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductLocation;
 import edu.jhuapl.sd.sig.mmtc.rollback.TimeCorrelationRollback;
+import edu.jhuapl.sd.sig.mmtc.util.Settable;
 
 import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.Optional;
 
-public abstract class OutputProductDefinition<T extends OutputProductDefinition.ResolvedProductLocation> {
-    public static List<OutputProductDefinition<?>> all() {
-        List<OutputProductDefinition<?>> all = new ArrayList<>(Arrays.asList(
-                new SclkKernelProductDefinition(),
-                new SclkScetProductDefinition(),
-                new TimeHistoryFileProductDefinition(),
-                new RawTlmTableProductDefinition(),
-                new UplinkCommandFileProductDefinition()
-        ));
+/**
+ * Defines common fields and methods common across all OutputProductDefinition implementations.
+ *
+ * @param <T> the type of ResolvedProductLocation that applies to the output product definition
+ */
+public abstract class OutputProductDefinition<T extends ResolvedProductLocation> {
+    protected final String name;
+    protected final Settable<Boolean> isBuiltIn = new Settable<>();
 
-        // ensure product definitions provide unique names
-        if (all.stream().map(def -> def.name).collect(Collectors.toSet()).size() != all.size()) {
-            throw new IllegalStateException("Please check your loaded configuration and/or plugins to ensure all output products have unique names.");
-        }
-
-        return Collections.unmodifiableList(all);
-    }
-
-    public final String name;
-
-    public OutputProductDefinition(String name) {
+    protected OutputProductDefinition(String name) {
         this.name = name;
     }
 
-    public abstract T resolveLocation(RollbackConfig config) throws MmtcException;
+    /**
+     * @return the name of the instance of the output product definition; must be unique at MMTC runtime
+     */
+    public final String getName() {
+        return this.name;
+    }
 
-    public abstract ProductWriteResult write(TimeCorrelationContext context) throws MmtcException;
+    public final void setIsBuiltIn(boolean newIsBuiltInStatus) {
+        isBuiltIn.set(newIsBuiltInStatus);
+    }
 
-    public abstract TimeCorrelationRollback.ProductRollbackOperation<?> getRollbackOperation(RollbackConfig config, Optional<String> newLatestProductVersion) throws MmtcException;
 
+    public final boolean isBuiltIn() {
+        return isBuiltIn.get();
+    }
+
+    /**
+     * 'Resolve' the location of the output product file(s) on disk for this definition.
+     *
+     * @param config the loaded MMTC configuration
+     * @return the resolved product location, given MMTC's configuration
+     * @throws MmtcException if any problem is encountered while determining the resolved product location
+     */
+    public abstract T resolveLocation(MmtcConfig config) throws MmtcException;
+
+    /**
+     * Where this product should be written, given the current time correlation
+     *
+     * @param context an object describing the time correlation inputs and results, possibly to be used in determining whether an output product should be written
+     * @return true if the product should be written, false otherwise
+     */
     public abstract boolean shouldBeWritten(TimeCorrelationContext context);
 
-    public abstract String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException;
+    /**
+     * Write the product to the filesystem.  Called once per successful time correlation run.
+     *
+     * @param context an object describing the time correlation inputs and results, possibly to help inform the contents of the product
+     * @return a ProductWriteResult containing the path to which updates were written as well as the new product 'version' (either a counter in the filename, or the new number of lines in the file)
+     * @throws MmtcException if there is an issue in writing the output product to disk
+     */
+    public abstract ProductWriteResult write(TimeCorrelationContext context) throws MmtcException;
 
-    public interface ResolvedProductLocation {
-    }
+    /**
+     * Assemble a ProductRollbackOperation describing the action to take in rolling back the version of the product output file(s) to an earlier version.
+     *
+     * @param config the loaded MMTC configuration
+     * @param newLatestProductVersion the product version that will become the newest after the rollback operation completes
+     * @return the assembled ProductRollbackOperation object describing the operation to execute
+     * @throws MmtcException if there is an issue in calculating the rollback operation
+     */
+    public abstract TimeCorrelationRollback.ProductRollbackOperation<?> getRollbackOperation(RollbackConfig config, Optional<String> newLatestProductVersion) throws MmtcException;
 
-    public static class ResolvedProductDirAndPrefix implements ResolvedProductLocation {
-        public final Path containingDirectory;
-        public final String filenamePrefix;
+    /**
+     * Returns a map of configuration keys to update to new values during sandbox creation, given the original
+     * MMTC configuration and the new directory where the MMTC sandbox will write further copies of this output product.
+     *
+     * Plugin-defined products are only permitted to update config keys with the prefix `product.plugin.[name].config.`
+     *
+     * @param originalConfig the original (non-sandboxed) MMTC configuration
+     * @param newProductOutputDir the new directory where the MMTC sandbox will write further copies of this output product
+     * @return a Map containing keys with values that should be changed for the new sandbox
+     */
+    public abstract Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputDir);
 
-        public ResolvedProductDirAndPrefix(Path containingDirectory, String filenamePrefix) {
-            this.containingDirectory = containingDirectory;
-            this.filenamePrefix = filenamePrefix;
-        }
-    }
-
-    public static class ResolvedProductPath implements ResolvedProductLocation {
-        public final Path pathToProduct;
-        public final AbstractTimeCorrelationTable table;
-
-        public ResolvedProductPath(Path pathToProduct, AbstractTimeCorrelationTable table) {
-            this.pathToProduct = pathToProduct;
-            this.table = table;
-        }
-    }
-
-    public static class ProductWriteResult {
-        public final Path path;
-        public final String newVersion;
-
-        public ProductWriteResult(Path path, String newVersion) {
-            this.path = path;
-            this.newVersion = newVersion;
-        }
-
-        public ProductWriteResult(Path path, int newVersion) {
-            this(path, Integer.toString(newVersion));
-        }
-    }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/OutputProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/OutputProductDefinition.java
@@ -66,8 +66,8 @@ public abstract class OutputProductDefinition<T extends ResolvedProductLocation>
      * Generates a string summarizing the hypothetical changes to an output product that would have been made had this been a real
      * run and the dry run flag wasn't passed. This generally involves all the steps usually taken to compute and produce an MMTC
      * output product except actually writing it to disk (except the SCLK kernel which must be written but will later be deleted).
-     * @param ctx
-     * @return
+     * @param ctx The current TimeCorrelationContext
+     * @return A string representation of any additions that would have been made to an output product
      * @throws MmtcException
      * @throws TextProductException
      * @throws IOException

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/OutputProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/OutputProductDefinition.java
@@ -1,93 +1,83 @@
 package edu.jhuapl.sd.sig.mmtc.products.definition;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
-import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
-import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
-import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductLocation;
+import edu.jhuapl.sd.sig.mmtc.products.model.AbstractTimeCorrelationTable;
 import edu.jhuapl.sd.sig.mmtc.rollback.TimeCorrelationRollback;
-import edu.jhuapl.sd.sig.mmtc.util.Settable;
 
 import java.nio.file.Path;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
-/**
- * Defines common fields and methods common across all OutputProductDefinition implementations.
- *
- * @param <T> the type of ResolvedProductLocation that applies to the output product definition
- */
-public abstract class OutputProductDefinition<T extends ResolvedProductLocation> {
-    protected final String name;
-    protected final Settable<Boolean> isBuiltIn = new Settable<>();
+public abstract class OutputProductDefinition<T extends OutputProductDefinition.ResolvedProductLocation> {
+    public static List<OutputProductDefinition<?>> all() {
+        List<OutputProductDefinition<?>> all = new ArrayList<>(Arrays.asList(
+                new SclkKernelProductDefinition(),
+                new SclkScetProductDefinition(),
+                new TimeHistoryFileProductDefinition(),
+                new RawTlmTableProductDefinition(),
+                new UplinkCommandFileProductDefinition()
+        ));
 
-    protected OutputProductDefinition(String name) {
+        // ensure product definitions provide unique names
+        if (all.stream().map(def -> def.name).collect(Collectors.toSet()).size() != all.size()) {
+            throw new IllegalStateException("Please check your loaded configuration and/or plugins to ensure all output products have unique names.");
+        }
+
+        return Collections.unmodifiableList(all);
+    }
+
+    public final String name;
+
+    public OutputProductDefinition(String name) {
         this.name = name;
     }
 
-    /**
-     * @return the name of the instance of the output product definition; must be unique at MMTC runtime
-     */
-    public final String getName() {
-        return this.name;
-    }
+    public abstract T resolveLocation(RollbackConfig config) throws MmtcException;
 
-    public final void setIsBuiltIn(boolean newIsBuiltInStatus) {
-        isBuiltIn.set(newIsBuiltInStatus);
-    }
-
-
-    public final boolean isBuiltIn() {
-        return isBuiltIn.get();
-    }
-
-    /**
-     * 'Resolve' the location of the output product file(s) on disk for this definition.
-     *
-     * @param config the loaded MMTC configuration
-     * @return the resolved product location, given MMTC's configuration
-     * @throws MmtcException if any problem is encountered while determining the resolved product location
-     */
-    public abstract T resolveLocation(MmtcConfig config) throws MmtcException;
-
-    /**
-     * Where this product should be written, given the current time correlation
-     *
-     * @param context an object describing the time correlation inputs and results, possibly to be used in determining whether an output product should be written
-     * @return true if the product should be written, false otherwise
-     */
-    public abstract boolean shouldBeWritten(TimeCorrelationContext context);
-
-    /**
-     * Write the product to the filesystem.  Called once per successful time correlation run.
-     *
-     * @param context an object describing the time correlation inputs and results, possibly to help inform the contents of the product
-     * @return a ProductWriteResult containing the path to which updates were written as well as the new product 'version' (either a counter in the filename, or the new number of lines in the file)
-     * @throws MmtcException if there is an issue in writing the output product to disk
-     */
     public abstract ProductWriteResult write(TimeCorrelationContext context) throws MmtcException;
 
-    /**
-     * Assemble a ProductRollbackOperation describing the action to take in rolling back the version of the product output file(s) to an earlier version.
-     *
-     * @param config the loaded MMTC configuration
-     * @param newLatestProductVersion the product version that will become the newest after the rollback operation completes
-     * @return the assembled ProductRollbackOperation object describing the operation to execute
-     * @throws MmtcException if there is an issue in calculating the rollback operation
-     */
     public abstract TimeCorrelationRollback.ProductRollbackOperation<?> getRollbackOperation(RollbackConfig config, Optional<String> newLatestProductVersion) throws MmtcException;
 
-    /**
-     * Returns a map of configuration keys to update to new values during sandbox creation, given the original
-     * MMTC configuration and the new directory where the MMTC sandbox will write further copies of this output product.
-     *
-     * Plugin-defined products are only permitted to update config keys with the prefix `product.plugin.[name].config.`
-     *
-     * @param originalConfig the original (non-sandboxed) MMTC configuration
-     * @param newProductOutputDir the new directory where the MMTC sandbox will write further copies of this output product
-     * @return a Map containing keys with values that should be changed for the new sandbox
-     */
-    public abstract Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputDir);
+    public abstract boolean shouldBeWritten(TimeCorrelationContext context);
 
+    public abstract String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException;
+
+    public interface ResolvedProductLocation {
+    }
+
+    public static class ResolvedProductDirAndPrefix implements ResolvedProductLocation {
+        public final Path containingDirectory;
+        public final String filenamePrefix;
+
+        public ResolvedProductDirAndPrefix(Path containingDirectory, String filenamePrefix) {
+            this.containingDirectory = containingDirectory;
+            this.filenamePrefix = filenamePrefix;
+        }
+    }
+
+    public static class ResolvedProductPath implements ResolvedProductLocation {
+        public final Path pathToProduct;
+        public final AbstractTimeCorrelationTable table;
+
+        public ResolvedProductPath(Path pathToProduct, AbstractTimeCorrelationTable table) {
+            this.pathToProduct = pathToProduct;
+            this.table = table;
+        }
+    }
+
+    public static class ProductWriteResult {
+        public final Path path;
+        public final String newVersion;
+
+        public ProductWriteResult(Path path, String newVersion) {
+            this.path = path;
+            this.newVersion = newVersion;
+        }
+
+        public ProductWriteResult(Path path, int newVersion) {
+            this(path, Integer.toString(newVersion));
+        }
+    }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/RawTlmTableProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/RawTlmTableProductDefinition.java
@@ -6,10 +6,12 @@ import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductPath;
 import edu.jhuapl.sd.sig.mmtc.products.model.RawTelemetryTable;
+import edu.jhuapl.sd.sig.mmtc.products.model.TableRecord;
 
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class RawTlmTableProductDefinition extends AppendedFileOutputProductDefinition {
     public RawTlmTableProductDefinition() {
@@ -24,6 +26,18 @@ public class RawTlmTableProductDefinition extends AppendedFileOutputProductDefin
     @Override
     public boolean shouldBeWritten(TimeCorrelationContext context) {
         return true;
+    }
+
+    @Override
+    public String getDryRunPrintout(TimeCorrelationContext ctx) {
+        TableRecord rawTlmTableRecord = RawTelemetryTable.calculateUpdatedRawTlmTable(ctx);
+        List<String> rtHeaders = new RawTelemetryTable(ctx.config.getRawTelemetryTablePath()).getHeaders();
+        Collection<String> rtValues = rawTlmTableRecord.getValues();
+        String zippedRtRow = IntStream.range(0, rtHeaders.size())
+                .mapToObj(i -> "\t" + rtHeaders.get(i) + "\t:\t"+new ArrayList<>(rtValues)
+                        .get(i))
+                .collect(Collectors.joining("\n"));
+        return String.format("[DRY RUN] Updated Raw TLM table records: \n%s", zippedRtRow);
     }
 
     @Override

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/RawTlmTableProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/RawTlmTableProductDefinition.java
@@ -1,10 +1,15 @@
 package edu.jhuapl.sd.sig.mmtc.products.definition;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
-import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductPath;
 import edu.jhuapl.sd.sig.mmtc.products.model.RawTelemetryTable;
-import edu.jhuapl.sd.sig.mmtc.products.model.TableRecord;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RawTlmTableProductDefinition extends AppendedFileOutputProductDefinition {
     public RawTlmTableProductDefinition() {
@@ -12,11 +17,8 @@ public class RawTlmTableProductDefinition extends AppendedFileOutputProductDefin
     }
 
     @Override
-    public ResolvedProductPath resolveLocation(RollbackConfig config) {
-        return new ResolvedProductPath(
-                config.getRawTelemetryTablePath(),
-                new RawTelemetryTable(config.getRawTelemetryTablePath())
-        );
+    public ResolvedProductPath resolveLocation(MmtcConfig config) {
+        return new ResolvedProductPath(config.getRawTelemetryTablePath());
     }
 
     @Override
@@ -25,14 +27,14 @@ public class RawTlmTableProductDefinition extends AppendedFileOutputProductDefin
     }
 
     @Override
-    public String getDryRunPrintout(TimeCorrelationContext ctx) {
-        TableRecord rawTlmTableRecord = RawTelemetryTable.calculateUpdatedRawTlmTable(ctx);
-        return String.format("Updated Raw TLM table records: %s \n %s", new RawTelemetryTable(ctx.config.getRawTelemetryTablePath()).getHeaders(),
-                rawTlmTableRecord.getValues().toString());
+    public ProductWriteResult appendToProduct(TimeCorrelationContext context) throws MmtcException {
+        return RawTelemetryTable.appendCorrelationFrameSamplesToRawTelemetryTable(context);
     }
 
     @Override
-    public ProductWriteResult writeToProduct(TimeCorrelationContext context) throws MmtcException {
-        return RawTelemetryTable.appendCorrelationFrameSamplesToRawTelemetryTable(context);
+    public Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputPath) {
+        final Map<String, String> confUpdates = new HashMap<>();
+        confUpdates.put("table.rawTelemetryTable.path", newProductOutputPath.toString());
+        return confUpdates;
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkKernelProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkKernelProductDefinition.java
@@ -57,20 +57,16 @@ public class SclkKernelProductDefinition extends EntireFileOutputProductDefiniti
      */
     @Override
     public String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException {
-        try {
-            SclkKernel.writeNewProduct(ctx);
-            ctx.newSclkKernel.get().updateFile();
+        SclkKernel.writeNewProduct(ctx);
+        // ctx.newSclkKernel.get().updateFile();
 
-            String[] newSclkEntries = ctx.newSclkKernel.get().getLastXRecords(2);
-            // If an interpolated clock change rate has replaced the rate in the existing SCLK kernel record, retrieve the two latest records.
-            // Otherwise, just return the new record
-            if (ctx.newSclkKernel.get().hasNewClkChgRateSet()) {
-                return String.format("[DRY RUN] Updated SCLK entries: \n" + newSclkEntries[0] + "\n" + newSclkEntries[1]);
-            } else {
-                return String.format("[DRY RUN] New SCLK entry: \n" + newSclkEntries[0]);
-            }
-        } catch (TimeConvertException | TextProductException | IOException e) {
-            throw new MmtcException("Unable to generate SCLK kernel", e);
+        String[] newSclkEntries = ctx.newSclkKernel.get().getLastXRecords(2);
+        // If an interpolated clock change rate has replaced the rate in the existing SCLK kernel record, retrieve the two latest records.
+        // Otherwise, just return the new record
+        if (ctx.newSclkKernel.get().hasNewClkChgRateSet()) {
+            return String.format("[DRY RUN] Updated SCLK entries: \n" + newSclkEntries[0] + "\n" + newSclkEntries[1]);
+        } else {
+            return String.format("[DRY RUN] New SCLK entry: \n" + newSclkEntries[0]);
         }
     }
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkKernelProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkKernelProductDefinition.java
@@ -6,7 +6,10 @@ import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductDirPrefixSuffix;
 import edu.jhuapl.sd.sig.mmtc.products.model.SclkKernel;
+import edu.jhuapl.sd.sig.mmtc.products.model.TextProductException;
+import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,6 +46,32 @@ public class SclkKernelProductDefinition extends EntireFileOutputProductDefiniti
     @Override
     public boolean shouldBeWritten(TimeCorrelationContext context) {
         return true;
+    }
+
+    /**
+     * This implementation is notable from that of other output products in that it does still write the SCLK kernel to
+     * disk. The only difference is that it's written to the /tmp directory and its latest two lines are recorded here.
+     * @param ctx The active run's TimeCorrelationContext
+     * @return A string with details about the changed SCLK kernel(s) ready to be logged.
+     * @throws MmtcException if there are any problems generating the SCLK kernel
+     */
+    @Override
+    public String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException {
+        try {
+            SclkKernel.writeNewProduct(ctx);
+            ctx.newSclkKernel.get().updateFile();
+
+            String[] newSclkEntries = ctx.newSclkKernel.get().getLastXRecords(2);
+            // If an interpolated clock change rate has replaced the rate in the existing SCLK kernel record, retrieve the two latest records.
+            // Otherwise, just return the new record
+            if (ctx.newSclkKernel.get().hasNewClkChgRateSet()) {
+                return String.format("[DRY RUN] Updated SCLK entries: \n" + newSclkEntries[0] + "\n" + newSclkEntries[1]);
+            } else {
+                return String.format("[DRY RUN] New SCLK entry: \n" + newSclkEntries[0]);
+            }
+        } catch (TimeConvertException | TextProductException | IOException e) {
+            throw new MmtcException("Unable to generate SCLK kernel", e);
+        }
     }
 
     @Override

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkKernelProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkKernelProductDefinition.java
@@ -6,10 +6,7 @@ import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductDirPrefixSuffix;
 import edu.jhuapl.sd.sig.mmtc.products.model.SclkKernel;
-import edu.jhuapl.sd.sig.mmtc.products.model.TextProductException;
-import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -49,7 +46,7 @@ public class SclkKernelProductDefinition extends EntireFileOutputProductDefiniti
     }
 
     /**
-     * This implementation is notable from that of other output products in that it does still write the SCLK kernel to
+     * This implementation is distinct from that of other output products in that it does still write the SCLK kernel to
      * disk. The only difference is that it's written to the /tmp directory and its latest two lines are recorded here.
      * @param ctx The active run's TimeCorrelationContext
      * @return A string with details about the changed SCLK kernel(s) ready to be logged.
@@ -58,7 +55,6 @@ public class SclkKernelProductDefinition extends EntireFileOutputProductDefiniti
     @Override
     public String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException {
         SclkKernel.writeNewProduct(ctx);
-        // ctx.newSclkKernel.get().updateFile();
 
         String[] newSclkEntries = ctx.newSclkKernel.get().getLastXRecords(2);
         // If an interpolated clock change rate has replaced the rate in the existing SCLK kernel record, retrieve the two latest records.

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkScetProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkScetProductDefinition.java
@@ -15,7 +15,10 @@ import java.util.Arrays;
 
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -50,12 +53,16 @@ public class SclkScetProductDefinition extends EntireFileOutputProductDefinition
     public String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException {
         SclkScetFile scetFile = SclkScetFile.calculateNewProduct(ctx);
         try {
-            scetFile.setSourceFilespec(ctx.config.getInputSclkKernelPath().toString()); // Can't use
+            scetFile.setSourceFilespec(ctx.newSclkKernel.get().getPath());
             scetFile.updateFile();
         } catch (TextProductException | TimeConvertException | IOException e) {
             throw new MmtcException("Failed to generate SCLKSCET file");
         }
-        return Arrays.toString(scetFile.getLastXRecords(1));
+        List<String> newProductLines = scetFile.getNewProductLines();
+        String newRecs = IntStream.range(Math.max(0, newProductLines.size() - scetFile.getNumAddedLines()), newProductLines.size())
+                .mapToObj(newProductLines::get)
+                .collect(Collectors.joining("\n\t"));
+        return String.format("[DRY RUN] New SCLKSCET file entry: \n\t%s\n\t%s", scetFile.getSclkscetFields(), newRecs);
     }
 
     /**

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkScetProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkScetProductDefinition.java
@@ -32,6 +32,7 @@ public class SclkScetProductDefinition extends EntireFileOutputProductDefinition
     public SclkScetProductDefinition() {
         super("SCLKSCET File");
     }
+    private final int ENTRIES_TO_PRINT = 4;
 
     @Override
     public ResolvedProductDirPrefixSuffix resolveLocation(MmtcConfig conf) throws MmtcException {
@@ -59,10 +60,10 @@ public class SclkScetProductDefinition extends EntireFileOutputProductDefinition
             throw new MmtcException("Failed to generate SCLKSCET file");
         }
         List<String> newProductLines = scetFile.getNewProductLines();
-        String newRecs = IntStream.range(Math.max(0, newProductLines.size() - scetFile.getNumAddedLines()), newProductLines.size())
+        String newRecs = IntStream.range(Math.max(0, newProductLines.size() - ENTRIES_TO_PRINT), newProductLines.size())
                 .mapToObj(newProductLines::get)
                 .collect(Collectors.joining("\n\t"));
-        return String.format("[DRY RUN] New SCLKSCET file entry: \n\t%s\n\t%s", scetFile.getSclkscetFields(), newRecs);
+        return String.format("[DRY RUN] Latest %d SCLKSCET file entries: \n\t%s\n\t%s", ENTRIES_TO_PRINT, scetFile.getSclkscetFields(), newRecs);
     }
 
     /**

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkScetProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkScetProductDefinition.java
@@ -17,6 +17,10 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Describes the set of SCLK kernel output products that MMTC performs operations on.
  * A single SCLK kernel is modeled by {@link SclkKernel}.

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkScetProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkScetProductDefinition.java
@@ -7,6 +7,11 @@ import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductDirPrefixSuffix;
 import edu.jhuapl.sd.sig.mmtc.products.model.SclkKernel;
 import edu.jhuapl.sd.sig.mmtc.products.model.SclkScetFile;
+import edu.jhuapl.sd.sig.mmtc.products.model.TextProductException;
+import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -35,6 +40,18 @@ public class SclkScetProductDefinition extends EntireFileOutputProductDefinition
     @Override
     public boolean shouldBeWritten(TimeCorrelationContext ctx) {
         return ctx.config.createSclkScetFile();
+    }
+
+    @Override
+    public String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException {
+        SclkScetFile scetFile = SclkScetFile.calculateNewProduct(ctx);
+        try {
+            scetFile.setSourceFilespec(ctx.config.getInputSclkKernelPath().toString()); // Can't use
+            scetFile.updateFile();
+        } catch (TextProductException | TimeConvertException | IOException e) {
+            throw new MmtcException("Failed to generate SCLKSCET file");
+        }
+        return Arrays.toString(scetFile.getLastXRecords(1));
     }
 
     /**

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkScetProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/SclkScetProductDefinition.java
@@ -60,7 +60,7 @@ public class SclkScetProductDefinition extends EntireFileOutputProductDefinition
             throw new MmtcException("Failed to generate SCLKSCET file");
         }
         List<String> newProductLines = scetFile.getNewProductLines();
-        String newRecs = IntStream.range(Math.max(0, newProductLines.size() - ENTRIES_TO_PRINT), newProductLines.size())
+        String newRecs = IntStream.range(Math.max(0, newProductLines.size() - (ENTRIES_TO_PRINT+1)), newProductLines.size()-1) // Ignore footer row
                 .mapToObj(newProductLines::get)
                 .collect(Collectors.joining("\n\t"));
         return String.format("[DRY RUN] Latest %d SCLKSCET file entries: \n\t%s\n\t%s", ENTRIES_TO_PRINT, scetFile.getSclkscetFields(), newRecs);

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/TimeHistoryFileProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/TimeHistoryFileProductDefinition.java
@@ -31,7 +31,7 @@ public class TimeHistoryFileProductDefinition extends AppendedFileOutputProductD
 
     @Override
     public String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException {
-        TimeHistoryFile timeHistFile = new TimeHistoryFile(ctx.config.getRawTelemetryTablePath(), ctx.config.getTimeHistoryFileExcludeColumns());
+        TimeHistoryFile timeHistFile = new TimeHistoryFile(ctx.config.getTimeHistoryFilePath(), ctx.config.getTimeHistoryFileExcludeColumns());
         TableRecord timeHistRecord = new TableRecord(timeHistFile.getHeaders());
         try {
             TimeHistoryFile.generateNewTimeHistRec(ctx, timeHistFile, timeHistRecord);

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/TimeHistoryFileProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/TimeHistoryFileProductDefinition.java
@@ -1,15 +1,20 @@
 package edu.jhuapl.sd.sig.mmtc.products.definition;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
-import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
+import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
-import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
-import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductPath;
+import edu.jhuapl.sd.sig.mmtc.products.model.RawTelemetryTable;
+import edu.jhuapl.sd.sig.mmtc.products.model.TableRecord;
+import edu.jhuapl.sd.sig.mmtc.products.model.TextProductException;
 import edu.jhuapl.sd.sig.mmtc.products.model.TimeHistoryFile;
+import edu.jhuapl.sd.sig.mmtc.tlm.FrameSample;
+import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
+import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 
-import java.nio.file.Path;
-import java.util.HashMap;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
 import java.util.Map;
+import java.util.Optional;
 
 public class TimeHistoryFileProductDefinition extends AppendedFileOutputProductDefinition {
     public TimeHistoryFileProductDefinition() {
@@ -17,24 +22,33 @@ public class TimeHistoryFileProductDefinition extends AppendedFileOutputProductD
     }
 
     @Override
-    public ResolvedProductPath resolveLocation(MmtcConfig config) {
-        return new ResolvedProductPath(config.getTimeHistoryFilePath());
+    public ResolvedProductPath resolveLocation(RollbackConfig config) {
+        return new ResolvedProductPath(
+                config.getTimeHistoryFilePath(),
+                new TimeHistoryFile(config.getTimeHistoryFilePath())
+        );
     }
 
     @Override
-    public boolean shouldBeWritten(TimeCorrelationContext ctx) {
-        return ctx.config.createTimeHistoryFile();
+    public boolean shouldBeWritten(TimeCorrelationContext context) {
+        return true;
     }
 
     @Override
-    public ProductWriteResult appendToProduct(TimeCorrelationContext ctx) throws MmtcException {
+    public String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException {
+        TimeHistoryFile timeHistFile = new TimeHistoryFile(ctx.config.getRawTelemetryTablePath(), ctx.config.getTimeHistoryFileExcludeColumns());
+        TableRecord timeHistRecord = new TableRecord(timeHistFile.getHeaders());
+        try {
+            TimeHistoryFile.generateNewTimeHistRec(ctx, timeHistFile, timeHistRecord);
+        } catch (TimeConvertException e) {
+            throw new RuntimeException(e);
+        }
+        return String.format("Updated Time History file records: %s \n %s", new TimeHistoryFile(ctx.config.getTimeHistoryFilePath()).getHeaders(),
+                timeHistRecord.getValues().toString());
+    }
+
+    @Override
+    public ProductWriteResult writeToProduct(TimeCorrelationContext ctx) throws MmtcException {
         return TimeHistoryFile.appendRowFor(ctx);
-    }
-
-    @Override
-    public Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputPath) {
-        final Map<String, String> confUpdates = new HashMap<>();
-        confUpdates.put("table.timeHistoryFile.path", newProductOutputPath.toString());
-        return confUpdates;
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/TimeHistoryFileProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/TimeHistoryFileProductDefinition.java
@@ -1,20 +1,15 @@
 package edu.jhuapl.sd.sig.mmtc.products.definition;
 
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
-import edu.jhuapl.sd.sig.mmtc.cfg.RollbackConfig;
+import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
-import edu.jhuapl.sd.sig.mmtc.products.model.RawTelemetryTable;
-import edu.jhuapl.sd.sig.mmtc.products.model.TableRecord;
-import edu.jhuapl.sd.sig.mmtc.products.model.TextProductException;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductPath;
 import edu.jhuapl.sd.sig.mmtc.products.model.TimeHistoryFile;
-import edu.jhuapl.sd.sig.mmtc.tlm.FrameSample;
-import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
-import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 
-import java.math.RoundingMode;
-import java.text.DecimalFormat;
+import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 public class TimeHistoryFileProductDefinition extends AppendedFileOutputProductDefinition {
     public TimeHistoryFileProductDefinition() {
@@ -22,33 +17,24 @@ public class TimeHistoryFileProductDefinition extends AppendedFileOutputProductD
     }
 
     @Override
-    public ResolvedProductPath resolveLocation(RollbackConfig config) {
-        return new ResolvedProductPath(
-                config.getTimeHistoryFilePath(),
-                new TimeHistoryFile(config.getTimeHistoryFilePath())
-        );
+    public ResolvedProductPath resolveLocation(MmtcConfig config) {
+        return new ResolvedProductPath(config.getTimeHistoryFilePath());
     }
 
     @Override
-    public boolean shouldBeWritten(TimeCorrelationContext context) {
-        return true;
+    public boolean shouldBeWritten(TimeCorrelationContext ctx) {
+        return ctx.config.createTimeHistoryFile();
     }
 
     @Override
-    public String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException {
-        TimeHistoryFile timeHistFile = new TimeHistoryFile(ctx.config.getRawTelemetryTablePath(), ctx.config.getTimeHistoryFileExcludeColumns());
-        TableRecord timeHistRecord = new TableRecord(timeHistFile.getHeaders());
-        try {
-            TimeHistoryFile.generateNewTimeHistRec(ctx, timeHistFile, timeHistRecord);
-        } catch (TimeConvertException e) {
-            throw new RuntimeException(e);
-        }
-        return String.format("Updated Time History file records: %s \n %s", new TimeHistoryFile(ctx.config.getTimeHistoryFilePath()).getHeaders(),
-                timeHistRecord.getValues().toString());
-    }
-
-    @Override
-    public ProductWriteResult writeToProduct(TimeCorrelationContext ctx) throws MmtcException {
+    public ProductWriteResult appendToProduct(TimeCorrelationContext ctx) throws MmtcException {
         return TimeHistoryFile.appendRowFor(ctx);
+    }
+
+    @Override
+    public Map<String, String> getSandboxConfigUpdates(MmtcConfig originalConfig, Path newProductOutputPath) {
+        final Map<String, String> confUpdates = new HashMap<>();
+        confUpdates.put("table.timeHistoryFile.path", newProductOutputPath.toString());
+        return confUpdates;
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/UplinkCommandFileProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/UplinkCommandFileProductDefinition.java
@@ -42,7 +42,7 @@ public class UplinkCommandFileProductDefinition extends EntireFileOutputProductD
     public String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException {
         try {
             UplinkCommand uplinkCommand = UplinkCmdFile.generateNewProduct(ctx);
-            return String.format("Generated Uplink Command string: \n"+ uplinkCommand);
+            return String.format("[DRY RUN] Generated Uplink Command string: \n\t"+ uplinkCommand);
         } catch (TimeConvertException e) {
             throw new MmtcException("Unable to generate the Uplink Command File: ", e);
         }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/UplinkCommandFileProductDefinition.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/UplinkCommandFileProductDefinition.java
@@ -6,6 +6,7 @@ import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductDirPrefixSuffix;
 import edu.jhuapl.sd.sig.mmtc.products.model.*;
+import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -35,6 +36,16 @@ public class UplinkCommandFileProductDefinition extends EntireFileOutputProductD
     @Override
     public boolean shouldBeWritten(TimeCorrelationContext context) {
         return context.config.isCreateUplinkCmdFile();
+    }
+
+    @Override
+    public String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException {
+        try {
+            UplinkCommand uplinkCommand = UplinkCmdFile.generateNewProduct(ctx);
+            return String.format("Generated Uplink Command string: \n"+ uplinkCommand);
+        } catch (TimeConvertException e) {
+            throw new MmtcException("Unable to generate the Uplink Command File: ", e);
+        }
     }
 
     /**

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RawTelemetryTable.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RawTelemetryTable.java
@@ -55,6 +55,24 @@ public class RawTelemetryTable extends AbstractTimeCorrelationTable {
     }
 
     /**
+     * Generate an updated RawTelemetryTable based on the current run, but don't append the new rows to the file.
+     * Intended for use in dry runs where the updated table is desired but not the changes to the file.
+     * @param ctx the current time correlation context from which to pull information for the output product
+     * @return an updated RawTelemetryTable
+     */
+    public static TableRecord calculateUpdatedRawTlmTable(TimeCorrelationContext ctx) {
+        final RawTelemetryTable rawTlmTable = new RawTelemetryTable(ctx.config.getRawTelemetryTablePath());
+        TableRecord rawTlmTableRecord = new TableRecord(rawTlmTable.getHeaders());
+
+        for (FrameSample sample : ctx.correlation.target.get().getSampleSet()) {
+            rawTlmTableRecord = sample.toRawTelemetryTableRecord(rawTlmTable.getHeaders());
+            rawTlmTableRecord.setValue(RawTelemetryTable.RUN_TIME, ctx.appRunTime.toString());
+        }
+
+        return rawTlmTableRecord;
+    }
+
+    /**
      * Write the current time correlation's sample set to the raw telemetry table.
      *
      * @param context the current time correlation context from which to pull information for the output product

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RawTelemetryTable.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RawTelemetryTable.java
@@ -66,8 +66,8 @@ public class RawTelemetryTable extends AbstractTimeCorrelationTable {
 
         for (FrameSample sample : ctx.correlation.target.get().getSampleSet()) {
             rawTlmTableRecord = sample.toRawTelemetryTableRecord(rawTlmTable.getHeaders());
-            rawTlmTableRecord.setValue(RawTelemetryTable.RUN_TIME, ctx.appRunTime.toString());
         }
+        rawTlmTableRecord.setValue(RawTelemetryTable.RUN_TIME, ctx.appRunTime.toString());
 
         return rawTlmTableRecord;
     }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RunHistoryFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RunHistoryFile.java
@@ -15,6 +15,7 @@ import java.util.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class RunHistoryFile extends AbstractTimeCorrelationTable {
     private static final Logger logger = LogManager.getLogger();
@@ -26,29 +27,106 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
     public static final String CLI_ARGS = "MMTC Invocation Args Used";
 
     private final List<String> headers;
+    private final List<String> newOutputProductHeadersToEstablishEmptyVersionsFor;
+    private final List<DeconfiguredOutputProductColPair> deconfiguredOutputProductsToTrack;
 
     public enum RollbackEntryOption {
         IGNORE_ROLLBACKS,
         INCLUDE_ROLLBACKS
     }
 
-    public RunHistoryFile(Path path, List<OutputProductDefinition<?>> allOutputProdDefs) {
+    public static class DeconfiguredOutputProductColPair {
+        public final String preRunColName;
+        public final String postRunColName;
+
+        private DeconfiguredOutputProductColPair(String preRunColName, String postRunColName) {
+            this.preRunColName = preRunColName;
+            this.postRunColName = postRunColName;
+        }
+
+        @Override
+        public String toString() {
+            return "DeconfiguredOutputProductColPair{" +
+                    "preRunColName='" + preRunColName + '\'' +
+                    ", postRunColName='" + postRunColName + '\'' +
+                    '}';
+        }
+    }
+
+    public RunHistoryFile(Path path, List<OutputProductDefinition<?>> allOutputProdDefs) throws MmtcException {
         super(path);
 
-        final List<String> headers = new ArrayList<>(Arrays.asList(
-                RUN_TIME,
-                RUN_ID,
-                ROLLEDBACK,
-                RUN_USER,
-                CLI_ARGS
-        ));
+        if (getFile().exists()) {
+            // if the file exists, read the order of its columns and update as necessary
+            // reading from disk helps ensure a stable ordering of product names, even when optional products are deconfigured
 
-        allOutputProdDefs.forEach(def -> {
-            headers.add(getPreRunProductColNameFor(def));
-            headers.add(getPostRunProductColNameFor(def));
-        });
+            final List<String> currentHeaders = new ArrayList<>(readExistingHeadersFromFile());
+            final List<String> newHeaders = new ArrayList<>();
 
-        this.headers = Collections.unmodifiableList(headers);
+            // look over all currently-configured output products to check whether there are now output product plugins defined since the last run
+            allOutputProdDefs.forEach(def -> {
+                final String prodPreRunColName = getPreRunProductColNameFor(def);
+                final String prodPostRunColName = getPostRunProductColNameFor(def);
+
+                if (! currentHeaders.contains(prodPreRunColName)) {
+                    currentHeaders.add(prodPreRunColName);
+                    newHeaders.add(prodPreRunColName);
+                }
+
+                if (! currentHeaders.contains(prodPostRunColName)) {
+                    currentHeaders.add(prodPostRunColName);
+                    newHeaders.add(prodPostRunColName);
+                }
+            });
+
+            this.headers = Collections.unmodifiableList(currentHeaders);
+            this.newOutputProductHeadersToEstablishEmptyVersionsFor = Collections.unmodifiableList(newHeaders);
+            this.deconfiguredOutputProductsToTrack = Collections.unmodifiableList(determineDeconfiguredProducts(allOutputProdDefs));
+        } else {
+            // if the file does not exist, establish a new column ordering
+
+            // default columns
+            final List<String> headers = new ArrayList<>(Arrays.asList(
+                    RUN_TIME,
+                    RUN_ID,
+                    ROLLEDBACK,
+                    RUN_USER,
+                    CLI_ARGS
+            ));
+
+            // a column for each currently-configured output product
+            allOutputProdDefs.forEach(def -> {
+                headers.add(getPreRunProductColNameFor(def));
+                headers.add(getPostRunProductColNameFor(def));
+            });
+
+            this.headers = Collections.unmodifiableList(headers);
+            this.newOutputProductHeadersToEstablishEmptyVersionsFor = new ArrayList<>();
+            this.deconfiguredOutputProductsToTrack = new ArrayList<>();
+        }
+    }
+
+    private List<DeconfiguredOutputProductColPair> determineDeconfiguredProducts(List<OutputProductDefinition<?>> allOutputProdDefs) throws MmtcException {
+        return readExistingHeadersFromFile().stream()
+                .filter(col -> col.startsWith("Latest"))
+                .filter(col -> col.endsWith("Pre-run"))
+                .filter(col -> allOutputProdDefs.stream().noneMatch(def -> col.equals(getPreRunProductColNameFor(def))))
+                .map(col -> new DeconfiguredOutputProductColPair(col, col.replace("Pre", "Post")))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void writeRecord(TableRecord record) throws MmtcException {
+        // modify the record to carry forward values of output product versions that are no longer written
+        TableRecord updatedRec = new TableRecord(record);
+
+        for (DeconfiguredOutputProductColPair deconfiguredOutProdColPair : deconfiguredOutputProductsToTrack) {
+            final String latestProdVersionPreAndPostRun = getLatestNonEmptyValueOfCol(deconfiguredOutProdColPair.postRunColName, RunHistoryFile.RollbackEntryOption.IGNORE_ROLLBACKS).orElse("-");
+            updatedRec.setValue(deconfiguredOutProdColPair.preRunColName, latestProdVersionPreAndPostRun);
+            updatedRec.setValue(deconfiguredOutProdColPair.postRunColName, latestProdVersionPreAndPostRun);
+        }
+
+        super.writeRecord(updatedRec);
     }
 
     public static String getPreRunProductColNameFor(OutputProductDefinition<?> def) {
@@ -76,6 +154,41 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
         return headers;
     }
 
+    public List<DeconfiguredOutputProductColPair> getDeconfiguredOutputProductsToTrack() {
+        return Collections.unmodifiableList(deconfiguredOutputProductsToTrack);
+    }
+
+    private List<String> readExistingHeadersFromFile() throws MmtcException {
+        try {
+            resetParser();
+            final List<String> existingHeaders = parser.getHeaderNames();
+            parser.close();
+            return existingHeaders;
+        } catch (IOException e) {
+            throw new MmtcException(e);
+        }
+    }
+
+    public void updateRowsForNewProducts() throws MmtcException {
+        if (! getFile().exists()) {
+            return;
+        }
+
+        if (newOutputProductHeadersToEstablishEmptyVersionsFor.isEmpty()) {
+            return;
+        }
+
+        logger.info("Updating Run History File with additional columns: " + newOutputProductHeadersToEstablishEmptyVersionsFor);
+        final List<TableRecord> allExistingRecords = readRecords(RollbackEntryOption.INCLUDE_ROLLBACKS);
+        for (TableRecord existingRecord : allExistingRecords) {
+            for (String newHeader : newOutputProductHeadersToEstablishEmptyVersionsFor) {
+                existingRecord.setValue(newHeader, "-");
+            }
+        }
+
+        writeToTableFromTableRecords(allExistingRecords);
+    }
+
     /**
      * Reads the existing RunHistoryFile and returns its contents as a list of TableRecords each representing
      * individual runs. It intentionally ignores any runs previously used in rollback as indicated by the "Rolled Back?"
@@ -86,7 +199,7 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
      */
     public List<TableRecord> readRecords(RollbackEntryOption option) throws MmtcException {
         List<TableRecord> records = new ArrayList<>();
-        if (!this.getFile().exists()) {
+        if (! this.getFile().exists()) {
             return records;
         }
 
@@ -99,7 +212,9 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
             }
 
             for (String column : getHeaders()) {
-                newRecord.setValue(column, record.get(column));
+                if (record.isMapped(column)) {
+                    newRecord.setValue(column, record.get(column));
+                }
             }
             records.add(newRecord);
         }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkKernel.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkKernel.java
@@ -394,8 +394,7 @@ public class SclkKernel extends TextProduct {
 
     /**
      * Generates a new SCLK Kernel but doesn't yet write it to file. Helper method for writeNewProduct
-     * @param ctx
-     * @return
+     * @param ctx The current TimeCorrelationContext
      * @throws TimeConvertException
      */
     public static void calculateNewProduct(TimeCorrelationContext ctx) throws TimeConvertException, TextProductException {

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkScetFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkScetFile.java
@@ -681,7 +681,7 @@ public class SclkScetFile extends TextProduct {
     @Override
     public void readSourceProduct() {
 
-        this.sourceProductLines = ctx.newSclkKernel.get().sourceProductLines;
+        this.sourceProductLines = ctx.newSclkKernel.get().newProductLines;
         sourceProductReadIn = true;
     }
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkScetFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkScetFile.java
@@ -200,9 +200,6 @@ public class SclkScetFile extends TextProduct {
         /* Add the leap second records to the end of the new SCLK/SCET records. */
         sclkScetRecs.addAll(leapSecRecs);
 
-        // record size of record set prior to adding new entries (but after leap second recs have been added)
-        int numInitialRecs = sclkScetRecs.size();
-
         /* Sort the SCLK/SCET records by SCET time. */
         sclkScetRecs.sort(Comparator.comparing(SclkScet::getScet));
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkScetFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkScetFile.java
@@ -3,7 +3,7 @@ package edu.jhuapl.sd.sig.mmtc.products.model;
 import edu.jhuapl.sd.sig.mmtc.app.MmtcException;
 import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationAppConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
-import edu.jhuapl.sd.sig.mmtc.products.definition.OutputProductDefinition;
+import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 
@@ -145,19 +145,7 @@ public class SclkScetFile extends TextProduct {
         endSclkScetTime = datetime;
     }
 
-    @Override
-    public String[] getLastXRecords(int numRecords) {
-        if(numRecords < 1) { return new String[0]; }
-        int lastRecordIndex = lastDataRecNum(sourceProductLines);
-
-        String[] records = new String[numRecords];
-        for(int i=lastRecordIndex-(numRecords-1), j=0;i < lastRecordIndex+1; i++, j++) {
-            records[j] = sourceProductLines.get(i);
-        }
-        return records;
-    }
-
-    /**
+     /**
      * Creates the new SCLK kernel product. Implements the corresponding abstract method in the parent class.
      *
      * @throws TextProductException if the product cannot be created
@@ -635,26 +623,6 @@ public class SclkScetFile extends TextProduct {
         return createFile();
     }
 
-    public static SclkScetFile calculateNewProduct(TimeCorrelationContext ctx) {
-        final TimeCorrelationAppConfig conf = ctx.config;
-        final String newSclkScetFilename = conf.getSclkScetFileBasename() +
-                conf.getSclkScetFileSeparator() +
-                ctx.newSclkVersionString.get() +
-                conf.getSclkScetFileSuffix();
-
-        // Create the new SCLK/SCET file from the newly-created SCLK kernel.
-        final SclkScetFile scetFile = new SclkScetFile(
-                conf,
-                newSclkScetFilename,
-                ctx.newSclkVersionString.get()
-        );
-
-        scetFile.setProductCreationTime(ctx.appRunTime);
-        scetFile.setClockTickRate(ctx.sclk_kernel_fine_tick_modulus.get());
-        SclkScet.setScetStrSecondsPrecision(conf.getSclkScetScetUtcPrecision());
-
-        return scetFile;
-    }
     /**
      * Writes a new SCLK-SCET File
      * @param ctx the current time correlation context from which to pull information for the output product
@@ -662,12 +630,27 @@ public class SclkScetFile extends TextProduct {
      * @throws MmtcException if the SCLK-SCET File cannot be written
      * @return a ProductWriteResult describing the updated product
      */
-    public static OutputProductDefinition.ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException {
+    public static ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException {
+        final TimeCorrelationAppConfig conf = ctx.config;
 
         try {
-            final SclkScetFile scetFile = calculateNewProduct(ctx);
+            final String newSclkScetFilename = conf.getSclkScetFileBasename() +
+                    conf.getSclkScetFileSeparator() +
+                    ctx.newSclkVersionString.get() +
+                    conf.getSclkScetFileSuffix();
 
-            return new OutputProductDefinition.ProductWriteResult(
+            // Create the new SCLK/SCET file from the newly-created SCLK kernel.
+            final SclkScetFile scetFile = new SclkScetFile(
+                    conf,
+                    newSclkScetFilename,
+                    ctx.newSclkVersionString.get()
+            );
+
+            scetFile.setProductCreationTime(ctx.appRunTime);
+            scetFile.setClockTickRate(ctx.sclk_kernel_fine_tick_modulus.get());
+            SclkScet.setScetStrSecondsPrecision(conf.getSclkScetScetUtcPrecision());
+
+            return new ProductWriteResult(
                     scetFile.createNewSclkScetFile(ctx.newSclkKernelPath.get().toString()),
                     ctx.newSclkVersionString.get()
             );

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TableRecord.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TableRecord.java
@@ -1,9 +1,6 @@
 package edu.jhuapl.sd.sig.mmtc.products.model;
 
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Supplier;
 
@@ -42,8 +39,8 @@ public class TableRecord {
      *
      * @return the list of values as strings.
      */
-    public Collection<String> getValues() {
-        return data.values();
+    public List<String> getValues() {
+        return new ArrayList<>(data.values());
     }
 
     /**

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TextProduct.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TextProduct.java
@@ -165,6 +165,15 @@ abstract class TextProduct {
 
 
     /**
+     * Gets the last x records in the original source product
+     *
+     * @param numRecords the number of records to return
+     * @return a String array of records in their original order, else an empty array if numRecords is invalid
+     */
+    public abstract String[] getLastXRecords(int numRecords);
+
+
+    /**
      * Creates a new product file from an existing source file and writes it to the directory
      * and name specified with the current time in UTC as the product creation time. This is
      * the top-level method in this class and the one that would be called from an external
@@ -200,12 +209,16 @@ abstract class TextProduct {
 
         try {
             /* Read the source file */
-            readSourceProduct();
-            createNewProduct();   /* <-- Abstract method defined in derived class. */
+            updateFile();
             return writeNewProduct();
         } catch (IOException e) {
             throw new TextProductException("Unable to read source product \"" + sourceFilespec + "\".", e);
         }
+    }
+
+    public void updateFile() throws TextProductException, IOException, TimeConvertException {
+        readSourceProduct();
+        createNewProduct();   /* <-- Abstract method defined in derived class. */
     }
 
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
@@ -154,7 +154,7 @@ public class TimeHistoryFile extends AbstractTimeCorrelationTable {
         final DecimalFormat tdf = new DecimalFormat("#.000000");
         tdf.setRoundingMode(RoundingMode.HALF_UP);
 
-        if (timeHistoryFile.exists() && ctx.correlation.interpolated_clock_change_rate.isSet()) {
+        if (timeHistoryFile.exists() && ctx.correlation.interpolated_clock_change_rate.isSet() && !ctx.config.isDryRun()) {
             Map<String, String> lastRecord = timeHistoryFile.readLastRecord();
             lastRecord.replace(TimeHistoryFile.INTERP_CLK_CHANGE_RATE, String.valueOf(ctx.correlation.interpolated_clock_change_rate.get()));
             timeHistoryFile.replaceLastRecord(lastRecord);

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
@@ -142,12 +142,16 @@ public class TimeHistoryFile extends AbstractTimeCorrelationTable {
     }
 
     /**
-     * Writes the next record for the Time History File (and updates the prior interpolated clock change rate, if applicable)
-     *
-     * @throws MmtcException if an unhandled MMTC configuraiton or other operation fails
-     * @throws TimeConvertException if a time conversion operation fails
+     * Helper function for creation of a new Time History file record. Takes a reference to a time history file record
+     * and modifies it in place so its caller can eventually write it or print it in the case of dry runs
+     * @param ctx
+     * @param timeHistoryFile
+     * @param newThfRec
+     * @return a TableRecord with the updated contents of the time history file
+     * @throws MmtcException
+     * @throws TimeConvertException
      */
-    private static void writeNewRow(TimeCorrelationContext ctx, TimeHistoryFile timeHistoryFile, TableRecord newThfRec) throws MmtcException, TimeConvertException, TextProductException {
+    public static void generateNewTimeHistRec(TimeCorrelationContext ctx, TimeHistoryFile timeHistoryFile, TableRecord newThfRec) throws MmtcException, TimeConvertException {
         final DecimalFormat tdf = new DecimalFormat("#.000000");
         tdf.setRoundingMode(RoundingMode.HALF_UP);
 
@@ -300,7 +304,16 @@ public class TimeHistoryFile extends AbstractTimeCorrelationTable {
         newThfRec.setValue(TimeHistoryFile.RADIO_ID,                  ctx.ancillary.active_radio_id.get());
         newThfRec.setValue(TimeHistoryFile.OSCILLATOR,                ctx.ancillary.oscillator_id.get());
         newThfRec.setValue(TimeHistoryFile.OSCILLATOR_TEMP_DEGC,      String.valueOf(ctx.ancillary.oscillator_temperature_deg_c.get()));
+    }
 
+    /**
+     * Writes the next record for the Time History File (and updates the prior interpolated clock change rate, if applicable)
+     *
+     * @throws MmtcException if an unhandled MMTC configuration or other operation from the helper function fails
+     * @throws TimeConvertException if a time conversion operation fails
+     */
+    private static void writeNewRow(TimeCorrelationContext ctx, TimeHistoryFile timeHistoryFile, TableRecord newThfRec) throws MmtcException, TimeConvertException, TextProductException {
+        generateNewTimeHistRec(ctx, timeHistoryFile, newThfRec);
         timeHistoryFile.writeRecord(newThfRec);
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
@@ -144,10 +144,9 @@ public class TimeHistoryFile extends AbstractTimeCorrelationTable {
     /**
      * Helper function for creation of a new Time History file record. Takes a reference to a time history file record
      * and modifies it in place so its caller can eventually write it or print it in the case of dry runs
-     * @param ctx
-     * @param timeHistoryFile
-     * @param newThfRec
-     * @return a TableRecord with the updated contents of the time history file
+     * @param ctx The current TimeCorrelationContext
+     * @param timeHistoryFile The Time hist file to be modified
+     * @param newThfRec A reference to the TableRecord that will be modified by this method
      * @throws MmtcException
      * @throws TimeConvertException
      */

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/UplinkCmdFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/UplinkCmdFile.java
@@ -47,6 +47,18 @@ public class UplinkCmdFile {
         return Paths.get(filespec);
     }
 
+    public static UplinkCommand generateNewProduct(TimeCorrelationContext ctx) throws TimeConvertException {
+        UplinkCommand uplinkCmd = new UplinkCommand(
+                ctx.correlation.target.get().getTargetSample().getTkSclkCoarse(),
+                ctx.correlation.target.get().getTargetSampleEtG(),
+                ctx.correlation.target.get().getTargetSampleTdtG(),
+                TimeConvert.tdtToTdtStr(ctx.correlation.target.get().getTargetSampleTdtG()),
+                ctx.correlation.predicted_clock_change_rate.get()
+        );
+
+        return uplinkCmd;
+    }
+
     /**
      * Writes a new Uplink Command File
      * @param ctx the current time correlation context from which to pull information for the output product
@@ -57,13 +69,7 @@ public class UplinkCmdFile {
     public static ProductWriteResult writeNewProduct(TimeCorrelationContext ctx) throws MmtcException {
         String cmdFilespec = "";
         try {
-            final UplinkCommand uplinkCmd = new UplinkCommand(
-                    ctx.correlation.target.get().getTargetSample().getTkSclkCoarse(),
-                    ctx.correlation.target.get().getTargetSampleEtG(),
-                    ctx.correlation.target.get().getTargetSampleTdtG(),
-                    TimeConvert.tdtToTdtStr(ctx.correlation.target.get().getTargetSampleTdtG()),
-                    ctx.correlation.predicted_clock_change_rate.get()
-            );
+            final UplinkCommand uplinkCmd = generateNewProduct(ctx);
 
             final String cmdFilename = ctx.config.getUplinkCmdFileBasename() +
                     ctx.appRunTime.toEpochSecond() +

--- a/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/SclkScetFileTests.java
+++ b/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/SclkScetFileTests.java
@@ -1,74 +1,17 @@
 package edu.jhuapl.sd.sig.mmtc;
 
-import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationAppConfig;
 import edu.jhuapl.sd.sig.mmtc.products.model.SclkScet;
 import edu.jhuapl.sd.sig.mmtc.products.model.SclkScetFile;
-import edu.jhuapl.sd.sig.mmtc.products.model.TextProductException;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import spice.basic.KernelDatabase;
-import spice.basic.SpiceErrorException;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.when;
 
 public class SclkScetFileTests {
     @BeforeAll
     static void teardown() throws TimeConvertException {
         TestHelper.ensureSpiceIsLoadedAndUnloadAllKernels();
-    }
-
-    /**
-     * Create a new SCLK/SCET file from an SCLK kernel. Uses 10-Jun-2019 kernel.
-     * Using NH data.
-     */
-    @Test
-    public void createNewSclkKScetFile_Test3() throws SpiceErrorException, TextProductException, TimeConvertException, IOException {
-        System.loadLibrary("JNISpice");
-
-        String sclkKernel = "src/test/resources/nh_kernels/sclk/new-horizons_1876.tsc";
-        KernelDatabase.load("src/test/resources/nh_kernels/lsk/naif0012.tls");
-        KernelDatabase.load(sclkKernel);
-
-        String dir         = "src/test/resources/SclkScetTests";
-        String filename    = "new-horizons_1876.scet";
-        String newFilePath = dir + File.separator + filename;
-        Path newFile       = Paths.get(newFilePath);
-
-        Files.deleteIfExists(newFile);
-
-        TimeCorrelationAppConfig config = Mockito.mock(TimeCorrelationAppConfig.class);
-        when(config.getSclkScetOutputDir()).thenReturn(Paths.get(dir));
-        when(config.getMissionName()).thenReturn("NEW_HORIZONS");
-        when(config.getMissionId()).thenReturn(98);
-        when(config.getSpacecraftName()).thenReturn("NEW_HORIZONS");
-        when(config.getSpacecraftId()).thenReturn(98);
-        when(config.getDataSetId()).thenReturn("SCLK_SCET");
-        when(config.getProducerId()).thenReturn("MMTC");
-        when(config.getSclkScetApplicableDurationDays()).thenReturn(0);
-        when(config.getNaifSpacecraftId()).thenReturn(-98);
-        when(config.getSclkScetLeapSecondRateMode()).thenReturn(TimeCorrelationAppConfig.SclkScetFileLeapSecondSclkRate.ONE);
-
-        SclkScetFile scetfile = new SclkScetFile(config, filename, "11");
-
-        SclkScet.setScetStrSecondsPrecision(3);
-        scetfile.setProductCreationTime(OffsetDateTime.now(ZoneOffset.UTC));
-        scetfile.setClockTickRate(50000);
-        // scetfile.setEndSclkScetTime(TimeConvert.parseIsoDoyUtcStr(scetfile.getProductDateTimeIsoUtc()));
-        scetfile.createNewSclkScetFile(sclkKernel);
     }
 
     @Test

--- a/mmtc-core/src/test/resources/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/TimeCorrelationConfigProperties.xml
@@ -34,8 +34,8 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
-  <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">false</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/home/lageja1/Desktop/MMTC/MMTC/mmtc-core/src/test/resources/tables/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
 
   <entry key="telemetry.tkOscTempWindowSec">60</entry>
 

--- a/mmtc-core/src/test/resources/TimeCorrelationConfigProperties.xml
+++ b/mmtc-core/src/test/resources/TimeCorrelationConfigProperties.xml
@@ -34,8 +34,8 @@
   <!--entry key="telemetry.source.pluginJarPrefix">mmtc-plugin-ampcs</entry-->
 
   <!-- Options for built-in Raw TLM Table telemetry source -->
-  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/home/lageja1/Desktop/MMTC/MMTC/mmtc-core/src/test/resources/tables/RawTelemetryTable_NH_reformatted.csv</entry>
-  <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">true</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.tableFile.path">/absolute/path/to/RawTelemetryTable_NH_reformatted.csv</entry>
+  <entry key="telemetry.source.plugin.rawTlmTable.readDownlinkDataRate">false</entry>
 
   <entry key="telemetry.tkOscTempWindowSec">60</entry>
 

--- a/mmtc-output-plugin-sdk/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/ExampleAppendedFileOutputProductDefinition.java
+++ b/mmtc-output-plugin-sdk/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/ExampleAppendedFileOutputProductDefinition.java
@@ -5,6 +5,8 @@ import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductPath;
+import edu.jhuapl.sd.sig.mmtc.products.model.TextProductException;
+import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -57,6 +59,13 @@ public class ExampleAppendedFileOutputProductDefinition extends AppendedFileOutp
     @Override
     public boolean shouldBeWritten(TimeCorrelationContext ctx) {
         return true;
+    }
+
+    @Override
+    public String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException, TextProductException, IOException, TimeConvertException {
+        return String.format("This is the product's results for this run in the form of a string that will be printed and logged when the dry run option is used.\n" +
+                "This will generally be the new entry that would have been added to the appended product: \n" +
+                "\t%s\n\t%d,%s,%.11f\n", HEADER, ctx.runId.get(), ctx.newSclkVersionString.get(), ctx.correlation.predicted_clock_change_rate.get());
     }
 
     @Override

--- a/mmtc-output-plugin-sdk/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/ExampleEntireFileOutputProductDefinition.java
+++ b/mmtc-output-plugin-sdk/src/main/java/edu/jhuapl/sd/sig/mmtc/products/definition/ExampleEntireFileOutputProductDefinition.java
@@ -5,6 +5,8 @@ import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfig;
 import edu.jhuapl.sd.sig.mmtc.correlation.TimeCorrelationContext;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ProductWriteResult;
 import edu.jhuapl.sd.sig.mmtc.products.definition.util.ResolvedProductDirPrefixSuffix;
+import edu.jhuapl.sd.sig.mmtc.products.model.TextProductException;
+import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -67,6 +69,13 @@ public class ExampleEntireFileOutputProductDefinition extends EntireFileOutputPr
     @Override
     public boolean shouldBeWritten(TimeCorrelationContext ctx) {
         return true;
+    }
+
+    @Override
+    public String getDryRunPrintout(TimeCorrelationContext ctx) throws MmtcException, TextProductException, IOException, TimeConvertException {
+        return String.format("This is the product's results for this run in the form of a string that will be printed and logged when the dry run option is used.\n" +
+                "This will generally be the latest x entries in the new product: \n" +
+                "\t%d,%s,%.11f\n", ctx.runId.get(), ctx.newSclkVersionString.get(), ctx.correlation.predicted_clock_change_rate.get());
     }
 
     @Override


### PR DESCRIPTION
Adds functionality for a new "dry run" mode invoked with -D or --dry-run passed in the command line invocation. When used, MMTC will not keep any of its output data products and will instead print the "hypothetical" outputs to the console and record them to the primary log. This includes the latest SCLK kernel triplet (only latest entry in most cases, or the latest two entries if the new kernel has a new clock change rate set as is the case in interpolated runs), the new row of the time history file, any new SCLKSCET entries if enabled, new raw TLM table lines if enabled, and uplink command entries if enabled. Because of JNISpice limitations, the SCLK kernel must be at least temporarily written to disk for the SCLKSCET file to be generated, so in the case of dry runs, a temporary SCLK kernel is written to the system /tmp/ dir and deleted after the SCLKSCET file is created. 

All output products logged/printed in dry runs match their "actual" outputs that get written to disk in non-dry runs ~with the exception of the SCLKSCET file which seems to have duplicate entries--see comment below for more details.~