### PR TITLE
[#7] Add optional behavior to insert smoothing entries in penultimate records to time correlation products

### DIFF
--- a/docs/MMTC_Users_Guide.adoc
+++ b/docs/MMTC_Users_Guide.adoc
@@ -1123,6 +1123,11 @@ source.name is not set to rawTlmTable.
 |INT
 |The maximum number of seconds after the time correlation target frame SCET for which to query GNC telemetry (SCLK/TDT(S)) values. This allows for the SCET of the queried channel to be approximate. The GNC TDT(S) and SCLK (for TDT(S)) values) are expected to have an identical SCET and the TDT(S) value is expected to be at or after the time correlation target frame's TDT(G).  If not set, a default value of 600 seconds (10 minutes) is used.
 
+|compute.clkchgrate.mode
+|OPTIONAL
+|STR
+|The default clock change rate mode that MMTC will use for new correlations.  This must be either the string 'compute-predict' or 'compute-interpolate'.  If unset, the default value is 'compute-interpolate'.  This mode may be overridden on the command line with additional modes (to assign a custom value or assign a value of 1.0 (i.e., no-drift)).
+
 |compute.tdtG.rate.predicted.lookBackDays
 |REQUIRED
 |FLT

--- a/docs/MMTC_Users_Guide.adoc
+++ b/docs/MMTC_Users_Guide.adoc
@@ -1133,6 +1133,16 @@ source.name is not set to rawTlmTable.
 |FLT
 |The maximum number of days to look back into previous contacts to get SCLK and TDT values when computing the predicted clock change rate. This value is a float type and will be converted to truncated integer whole hours internally. If there is no time correlation record in the input SCLK Kernel within this amount of time prior to the current sample time, the MMTC will terminate with an error.
 
+|compute.additionalSmoothingCorrelationRecordInsertion.enabled
+|OPTIONAL
+|BOOL
+|Whether to insert an additional 'smoothing' correlation triplet into written SCLK kernels and SCLK-SCET files that ensures SCLK-SCET continuity with `--clkchgrate-compute p`, `--clkchgrate-nodrift`, or `--clkchgrate-assign` modes.  This helps keep time conversions stable between correlation output products, for the majority of the covered SCLK or SCET times, while providing continuity in the SCLK-SCET relationship.  Not useful or applicable when using `--clkchgrate-compute i`; MMTC will not allow runs with both `--clkchgrate-i` and this mode enabled.  It is not recommended to mix runs with interpolated mode and smoothing records enabled. Defaults to `false`.
+
+|compute.additionalSmoothingCorrelationRecordInsertion.coarseSclkTickDuration
+|OPTIONAL
+|INT
+|A positive integer that specifies how much earlier the additional 'smoothing' record should be placed, as compared to the new final 'actual' correlation record, in terms of SCLK coarse ticks. In other words, this value is the SCLK duration of the record that 'smooths' the transition from one correlation record to the next. Default value is `100`.
+
 |compute.tdtS.threshold.errorMsecWarning
 |OPTIONAL
 |DBL

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/TimeCorrelationAncillaryOperations.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/TimeCorrelationAncillaryOperations.java
@@ -48,12 +48,12 @@ public class TimeCorrelationAncillaryOperations {
 
     private double computeDt() throws TimeConvertException, TextProductException {
         // The TDT(G) value can be either a calendar string or a numeric value inside an SCLK kernel
-        String tdtGPrevStr = ctx.currentSclkKernel.get().getLastRecValue(SclkKernel.TDTG);
+        String tdtGPrevStr = ctx.currentSclkKernel.get().getLastRecValue(SclkKernel.TRIPLET_TDTG_FIELD_INDEX);
         final double tdtGPrev;
         if (SclkKernel.isNumVal(tdtGPrevStr)) {
             tdtGPrev = Double.parseDouble(tdtGPrevStr);
         } else {
-            tdtGPrev = TimeConvert.tdtStrToTdt(tdtGPrevStr.replace("@", ""));
+            tdtGPrev = TimeConvert.tdtCalStrToTdt(tdtGPrevStr.replace("@", ""));
         }
 
         return (ctx.correlation.target.get().getTargetSampleTdtG() - tdtGPrev) / TimeConvert.SECONDS_PER_DAY;

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/TimeCorrelationApp.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/app/TimeCorrelationApp.java
@@ -443,7 +443,7 @@ public class TimeCorrelationApp {
             final double predictedClockChangeRate;
 
             final TimeCorrelationAppConfig.ClockChangeRateMode actualClockChangeRateMode;
-            if (config.getClockChangeRateMode().equals(TimeCorrelationAppConfig.ClockChangeRateMode.COMPUTE_INTERPOLATED) && ctx.currentSclkKernel.get().getSourceProductDataRecCount() == 1) {
+            if (config.getClockChangeRateMode().equals(TimeCorrelationAppConfig.ClockChangeRateMode.COMPUTE_INTERPOLATE) && ctx.currentSclkKernel.get().getSourceProductDataRecCount() == 1) {
                 /*
                  * If this is the very first run of the application for a mission, the input SCLK Kernel is assumed to be the seed kernel.
                  * In this case and ONLY in this case, only compute the predicted clock change rate value, so as
@@ -451,7 +451,7 @@ public class TimeCorrelationApp {
                  * CLKRATE method anyway for the first few runs.
                  */
                 logger.warn("Not computing interpolated rate for prior SCLK kernel record so as not to overwrite seed kernel entry; switching clock change rate mode to compute-predicted");
-                actualClockChangeRateMode = TimeCorrelationAppConfig.ClockChangeRateMode.COMPUTE_PREDICTED;
+                actualClockChangeRateMode = TimeCorrelationAppConfig.ClockChangeRateMode.COMPUTE_PREDICT;
             } else {
                 actualClockChangeRateMode = config.getClockChangeRateMode();
             }
@@ -466,10 +466,10 @@ public class TimeCorrelationApp {
                 case ASSIGN:
                     predictedClockChangeRate = config.getClockChangeRateAssignedValue();
                     break;
-                case COMPUTE_INTERPOLATED:
+                case COMPUTE_INTERPOLATE:
                     ctx.correlation.interpolated_clock_change_rate.set(computeInterpolatedClkChgRate(curr_sclk_coarse, curr_tdt_g));
                     // purposeful fall-through to also compute the predicted (forward-looking) clock change rate
-                case COMPUTE_PREDICTED:
+                case COMPUTE_PREDICT:
                     predictedClockChangeRate = computePredictedClkChgRate(tcTarget.getTargetSample().getTkSclkCoarse(), curr_tdt_g);
 
                     // Compute and record the drift rate of the SCLK counter in ms/day

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/CorrelationCommandLineConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/CorrelationCommandLineConfig.java
@@ -101,7 +101,7 @@ public class CorrelationCommandLineConfig implements IConfiguration {
                 "s",
                 "with-smoothing-record",
                 true,
-                "Insert an additional 'smoothing' record to ensure continuity in SCLK-TDT relationship, at the given number of SCLK coarse ticks earlier than the new correlation record. Cannot be used with clkchgrate-compute interpolate. If specified, overrides the presence of related configuration in the configuration file."
+                "Insert an additional 'smoothing' record to ensure continuity in SCLK-TDT relationship, at the given number of SCLK coarse ticks earlier than the new correlation record. Cannot be used with clkchgrate-compute i. If specified, overrides the presence of related configuration in the configuration file."
         );
 
         opts.addOption(
@@ -227,10 +227,10 @@ public class CorrelationCommandLineConfig implements IConfiguration {
 
             switch (method) {
                 case "i":
-                    clockChangeRateMode = ClockChangeRateMode.COMPUTE_INTERPOLATED;
+                    clockChangeRateMode = ClockChangeRateMode.COMPUTE_INTERPOLATE;
                     break;
                 case "p":
-                    clockChangeRateMode = ClockChangeRateMode.COMPUTE_PREDICTED;
+                    clockChangeRateMode = ClockChangeRateMode.COMPUTE_PREDICT;
                     break;
                 default:
                     throw new ParseException("Invalid clock change rate compute method: " + method);
@@ -274,7 +274,7 @@ public class CorrelationCommandLineConfig implements IConfiguration {
         boolean isDoNotInsertAdditionalSmoothingRecord = cmdLine.hasOption("x") || cmdLine.hasOption("without-smoothing-record");
 
         if (isInsertAdditionalSmoothingRecord && isDoNotInsertAdditionalSmoothingRecord) {
-            throw new IllegalStateException("The command-line arguments specified mutually incompatible options to both enable and disable the additional smoothing record.  Please address and rerun.");
+            throw new IllegalStateException("The command-line arguments specified incompatible options to both enable and disable the additional smoothing record.  Please address and rerun.");
         }
 
         this.isInsertAdditionalSmoothingRecordExplicitlySet = true;

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/MmtcConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/MmtcConfig.java
@@ -345,6 +345,28 @@ public abstract class MmtcConfig {
     }
 
     /**
+     * Get whether to insert an additional 'smoothing' record to the SCLK kernel and SCLK-SCET files.  If unset,
+     * defaults to false
+     * @return true if this feature is enabled, false otherwise
+     */
+    public boolean isAdditionalSmoothingCorrelationRecordInsertionEnabled() {
+        return timeCorrelationConfig.getConfig().getBoolean("compute.additionalSmoothingCorrelationRecordInsertion.enabled", false);
+    }
+
+    /**
+     * Get whether to insert an additional 'smoothing' record to the SCLK kernel and SCLK-SCET files.  If unset,
+     * defaults to false
+     * @return true if this feature is enabled, false otherwise
+     */
+    public int getAdditionalSmoothingCorrelationRecordInsertionCoarseSclkTickDuration() throws MmtcException {
+        final int val = timeCorrelationConfig.getConfig().getInt("compute.additionalSmoothingCorrelationRecordInsertion.coarseSclkTickDuration", 100);
+        if (val < 1) {
+            throw new MmtcException("The config key 'compute.additionalSmoothingCorrelationRecordInsertion.coarseSclkTickDuration' must have a value of 1 or greater.");
+        }
+        return val;
+    }
+
+    /**
      * Get the maximum virtual channel frame counter value a frame can be assigned before the next frame's virtual
      * channel frame index is assigned zero. Depending on mission, this can range anywhere from a few hundred to 
      * a few million, so MMTC needs to know when to expect a VCFC rollover.
@@ -817,13 +839,12 @@ public abstract class MmtcConfig {
      * purposes of computing the predicted clock change rate. This specifies how far back is too far
      * in finding the previous time correlation in computing Predicted CLKRATE. This value is read-in
      * from the config parameters as a floating point type representing days, multiplied by 24 to produce
-     * hours, and then the fractional part truncated to the integer whole hour.
+     * hours
      *
      * @return the maximum number of hours to look back
      */
-    public Integer getMaxPredictedClkRateLookBackHours() {
-        Float maxLookBack = timeCorrelationConfig.getConfig().getFloat("compute.tdtG.rate.predicted.maxLookBackDays") * 24;
-        return new Integer(maxLookBack.intValue());
+    public double getMaxPredictedClkRateLookBackHours() {
+        return timeCorrelationConfig.getConfig().getFloat("compute.tdtG.rate.predicted.maxLookBackDays") * 24.0;
     }
 
     /**
@@ -873,7 +894,6 @@ public abstract class MmtcConfig {
     public SclkScetFileLeapSecondSclkRate getSclkScetLeapSecondRateMode() {
         final String mode = timeCorrelationConfig.getConfig().getString("product.sclkScetFile.leapSecondSclkRateMode", "PRIOR_RATE");
         return SclkScetFileLeapSecondSclkRate.valueOf(mode);
-
     }
 
     /**

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/MmtcConfig.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/cfg/MmtcConfig.java
@@ -36,11 +36,11 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 /**
- * Defines a wrapper of the configuration parameters for the entire time correlation. These include the
- * parameters read from the TimeCorrelationConfigProperties.xml file, the options provided buy a user from
- * the command line, Ground Station Map associations, and the SCLK Partition Map associations.
+ * A class assisting with loading and providing access to values in file-based configuration. These include the
+ * parameters read from the TimeCorrelationConfigProperties.xml file, Ground Station Map associations,
+ * and the SCLK Partition Map associations.
  *
- * Functions in this class also provide access to each item in the TimeCorrelationConfigProperties.xml
+ * Functions in this class provide access to each item in the TimeCorrelationConfigProperties.xml
  * configuration parameters file.
  */
 public abstract class MmtcConfig {

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/correlation/CorrelationInfo.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/correlation/CorrelationInfo.java
@@ -2,6 +2,7 @@ package edu.jhuapl.sd.sig.mmtc.correlation;
 
 import edu.jhuapl.sd.sig.mmtc.app.TimeCorrelationTarget;
 import edu.jhuapl.sd.sig.mmtc.cfg.TimeCorrelationAppConfig;
+import edu.jhuapl.sd.sig.mmtc.products.model.SclkKernel;
 import edu.jhuapl.sd.sig.mmtc.util.Settable;
 
 import java.time.OffsetDateTime;
@@ -19,15 +20,10 @@ public class CorrelationInfo {
     public final Settable<Double> predicted_clock_change_rate = new Settable<>();
     public final Settable<Double> interpolated_clock_change_rate = new Settable<>();
 
-    // other computed information
-    // public final Settable<Double> etG = new Settable<>();
+    public Settable<SclkKernel.CorrelationTriplet> smoothingTriplet = new Settable<>();
 
+    // other computed information
     public final Settable<Double> sclk_drift_ms_per_day = new Settable<>();
     public final Settable<String> equivalent_scet_utc_for_tdt_g_iso_doy = new Settable<>();
     public final Settable<OffsetDateTime> equivalent_scet_utc_for_tdt_g = new Settable<>();
-
-    public final Settable<Double> tdt_s_error_ms = new Settable<>();
-
-
-
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/filter/ContactFilter.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/filter/ContactFilter.java
@@ -104,7 +104,7 @@ public class ContactFilter {
 
             // The SCLK and TDT(G) from the previous time correlation (i.e., from last contact).
             int sclk_p = TimeConvert.encSclkToSclk(naifScId, sclk_kernel_fine_tick_modulus, priorEncSclk).intValue();
-            Double tdtG_p = TimeConvert.tdtStrToTdt(tdt_g0_previous);
+            Double tdtG_p = TimeConvert.tdtCalStrToTdt(tdt_g0_previous);
 
             logger.debug("ContactFilter.process(): Previous contact SCLK = " + sclk_p +
                     ", Previous TDT(G) = " + tdtG_p + "." + " Current SCLK = " + targetSample.getTkSclkCoarse() +

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RunHistoryFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/RunHistoryFile.java
@@ -25,6 +25,7 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
     public static final String ROLLEDBACK = "Rolled Back?";
     public static final String RUN_USER = "Run User";
     public static final String CLI_ARGS = "MMTC Invocation Args Used";
+    public static final String SMOOTHING_TRIPLET_TDT = "Smoothing Triplet TDT";
 
     private final List<String> headers;
     private final List<String> newOutputProductHeadersToEstablishEmptyVersionsFor;
@@ -91,7 +92,8 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
                     RUN_ID,
                     ROLLEDBACK,
                     RUN_USER,
-                    CLI_ARGS
+                    CLI_ARGS,
+                    SMOOTHING_TRIPLET_TDT
             ));
 
             // a column for each currently-configured output product
@@ -207,7 +209,7 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
 
         for (CSVRecord record : parser) {
             TableRecord newRecord = new TableRecord(getHeaders());
-            if (record.get("Rolled Back?").equals("true") && option.equals(RollbackEntryOption.IGNORE_ROLLBACKS)) {
+            if (record.get(ROLLEDBACK).equals("true") && option.equals(RollbackEntryOption.IGNORE_ROLLBACKS)) {
                 continue;
             }
 
@@ -224,6 +226,13 @@ public class RunHistoryFile extends AbstractTimeCorrelationTable {
             throw new MmtcRollbackException("Rollback failed while reading RunHistoryFile: could not close parser");
         }
         return records;
+    }
+
+    public Collection<String> getSmoothingTripletTdtGValsToIgnoreDuringLookback() throws MmtcException {
+        return readRecords(RollbackEntryOption.IGNORE_ROLLBACKS).stream()
+                .map(rec -> rec.getValue(SMOOTHING_TRIPLET_TDT))
+                .filter(tdtG -> ! tdtG.equals("-"))
+                .collect(Collectors.toSet());
     }
 
     private TableRecord getRunHistoryRowForRunId(String runId) throws MmtcException {

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkKernel.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkKernel.java
@@ -16,6 +16,8 @@ import java.text.DecimalFormat;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
 
 /**
  * The SclkKernel class creates the SCLK kernel file and its contents. The SCLK Kernel is the primary product of MMTC.
@@ -23,25 +25,18 @@ import java.util.ArrayList;
 public class SclkKernel extends TextProduct {
     public static final String FILE_SUFFIX = ".tsc";
 
+    /* The number of fields in an SCLK kernel triplet time correlation record. */
+    public static final int NUM_FIELDS_IN_TRIPLET = 3;
+
     /* Indices for the fields in a triplet record. */
-    public static final int ENCSCLK    = 0;
-    public static final int TDTG       = 1;
-    public static final int CLKCHGRATE = 2;
+    public static final int TRIPLET_ENCSCLK_FIELD_INDEX = 0;
+    public static final int TRIPLET_TDTG_FIELD_INDEX = 1;
+    public static final int TRIPLET_CLKCHGRATE_FIELD_INDEX = 2;
 
-    /* Encoded SCLK value for the new time correlation record. */
-    private Double encSclk;
-
-    /* TDT value in calendar string form for the new time correlation record. */
-    private String tdtStr;
-
-    /* Clock change rate for the new time correlation record. */
-    private Double clockChgRate;
+    private Optional<CorrelationTriplet> newTriplet = Optional.empty();
 
     /* New interpolated clock change reate to ovewrite the predicted rate in the existing SCLK kernel record. */
     private Double updatedClockChgRate;
-
-    /* Indicates if the new time correlation data have been set. */
-    private boolean newTripletSet = false;
 
     /* Indicates if an interpolated clock change rate is to replace the rate in the existing SCLK kernel record. */
     private boolean newClkChgRateSet = false;
@@ -49,9 +44,7 @@ public class SclkKernel extends TextProduct {
     /* The zero-based index of the last data record in the SCLK kernel (i.e., the last record containing a triplet. */
     private int endDataNum = -1;
 
-    /* The number of fields in an SCLK kernel triplet time correlation record. */
-    private int numFieldsInRecord = 3;
-
+    private Optional<CorrelationTriplet> smoothingTriplet = Optional.empty();
 
     /**
      * Class constructor.
@@ -101,10 +94,19 @@ public class SclkKernel extends TextProduct {
      * @param clockChgRate IN clock change rate
      */
     public void setNewTriplet(Double encSclk, String tdtStr, Double clockChgRate) {
-        this.encSclk      = encSclk;
-        this.tdtStr       = tdtStr;
-        this.clockChgRate = clockChgRate;
-        newTripletSet     = true;
+        this.newTriplet = Optional.of(new CorrelationTriplet(encSclk, tdtStr, clockChgRate));
+    }
+
+    public static class CorrelationTriplet {
+        public final double encSclk;
+        public final String tdtStr;
+        public final double clkChgRate;
+
+        public CorrelationTriplet(double encSclk, String tdtStr, double clkChgRate) {
+            this.encSclk = encSclk;
+            this.tdtStr = tdtStr;
+            this.clkChgRate = clkChgRate;
+        }
     }
 
 
@@ -140,35 +142,40 @@ public class SclkKernel extends TextProduct {
             throw new TextProductException("Valid source SCLK Kernel data have not been loaded.");
         }
 
-        if (newTripletSet && sourceProductReadIn) {
-
-            /* Create the new SCLK kernel from the Old. */
-            newProductLines = new ArrayList<>(sourceProductLines);
-
-            /* Replace the FILENAME field. */
-            String newname = "FILENAME = " + "\"" + getName() + "\"";
-            replaceFieldValue("FILENAME =", newname, "=");
-
-            /* Replace the CREATION_DATE field. */
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MMM-yyyy");
-            OffsetDateTime productCreationTime = getProductCreationTime();
-            String newDate = "CREATION_DATE = " + "\"" + productCreationTime.format(formatter) + "\"";
-            replaceFieldValue("CREATION_DATE =", newDate, "=");
-
-            /* Replace the clock change rate of the last record in the product with the new rate, if selected. */
-            if (newClkChgRateSet) {
-                String updatedTriplet = replaceChgRate();
-                newProductLines.remove(endDataNum);
-                newProductLines.add(endDataNum, updatedTriplet);
-            }
-
-            /* Form a new time correlation record from the triplet values and append it to the SCLK kernel data. */
-            String newTriplet = assembleNewTripletRecord();
-            newProductLines.add(endDataNum+1, newTriplet);
-        }
-        else {
+        if (! (newTriplet.isPresent() && sourceProductReadIn)) {
             throw new TextProductException("Cannot create SCLK kernel. New record values have not been set.");
         }
+
+        /* Create the new SCLK kernel from the Old. */
+        newProductLines = new ArrayList<>(sourceProductLines);
+
+        /* Replace the FILENAME field. */
+        String newname = "FILENAME = " + "\"" + getName() + "\"";
+        replaceFieldValue("FILENAME =", newname, "=");
+
+        /* Replace the CREATION_DATE field. */
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MMM-yyyy");
+        OffsetDateTime productCreationTime = getProductCreationTime();
+        String newDate = "CREATION_DATE = " + "\"" + productCreationTime.format(formatter) + "\"";
+        replaceFieldValue("CREATION_DATE =", newDate, "=");
+
+        final String previousFinalRecordForFormattingReference = sourceProductLines.get(endDataNum);
+
+        // Replace the clock change rate of the last record in the product with the new rate, if selected
+        if (newClkChgRateSet) {
+            String updatedTriplet = replaceChgRate();
+            newProductLines.remove(endDataNum);
+            newProductLines.add(endDataNum, updatedTriplet);
+        }
+
+        // Append the smoothing record, if selected
+        if (smoothingTriplet.isPresent()) {
+            newProductLines.add(endDataNum + 1, assembleNewTripletRecord(smoothingTriplet.get(), previousFinalRecordForFormattingReference));
+            endDataNum += 1;
+        }
+
+        // Form a new time correlation record from the triplet values and append it to the SCLK kernel data
+        newProductLines.add(endDataNum + 1, assembleNewTripletRecord(newTriplet.get(), previousFinalRecordForFormattingReference));
     }
 
 
@@ -183,13 +190,13 @@ public class SclkKernel extends TextProduct {
     private String replaceChgRate() throws TextProductException {
 
         String record          = sourceProductLines.get(endDataNum);
-        String[] tripletFields = parseRecord(record, numFieldsInRecord);
+        String[] tripletFields = parseRecord(record, NUM_FIELDS_IN_TRIPLET);
 
         /* Replace the existing clock change rate value with the new one. */
         String newChgRateStr = formatChgRateStr(updatedClockChgRate);
 
         /* Replace the clock change rate. It is the third field of the SCLK kernel record. */
-        String record1 = record.replaceFirst(tripletFields[CLKCHGRATE], newChgRateStr);
+        String record1 = record.replaceFirst(tripletFields[TRIPLET_CLKCHGRATE_FIELD_INDEX], newChgRateStr);
 
         return record1;
     }
@@ -201,7 +208,7 @@ public class SclkKernel extends TextProduct {
      * @param clkChgRate the clock change rate in numeric form
      * @return the clock change rate as a formatted string
      */
-    private String formatChgRateStr(Double clkChgRate) {
+    private static String formatChgRateStr(Double clkChgRate) {
         DecimalFormat clkChgRateFormat = new DecimalFormat("0.00000000000");
         clkChgRateFormat.setRoundingMode(RoundingMode.HALF_UP);
         String chgRateStr = clkChgRateFormat.format(clkChgRate);
@@ -226,7 +233,7 @@ public class SclkKernel extends TextProduct {
         // Remove any parentheses that might be in the record.
         String recstr  = record.replace("(", "");
         recstr         = recstr.replace(")", "");
-        String[] tripletFields = parseRecord(recstr, numFieldsInRecord);
+        String[] tripletFields = parseRecord(recstr, NUM_FIELDS_IN_TRIPLET);
 
         return tripletFields[index];
     }
@@ -240,30 +247,38 @@ public class SclkKernel extends TextProduct {
      * @return the parsed record that is the number of hours back
      * @throws TextProductException if the prior record could not be found
      */
-    public String[] getPriorRec(Double fromTdt, Double lookBackHours) throws TextProductException {
-        String[] tripletFields = null;
-
+    public String[] getPriorRec(Double fromTdt, Double lookBackHours, Collection<String> smoothingRecordTdtStringsToIgnore) throws TextProductException {
         try {
-            double minLookbackSeconds = lookBackHours * 3600.;
+            final double minLookbackSeconds = lookBackHours * 3600.;
 
             for (int i = endDataNum; i > 0; i--) {
                 String record = sourceProductLines.get(i);
+
                 if (! isDataRecord(record)) {
                     throw new TextProductException("Look back time invalid for the specified SCLK kernel.");
                 }
-                tripletFields = parseRecord(record, numFieldsInRecord);
-                double tdtsec = TimeConvert.tdtStrToTdt(tripletFields[TDTG].substring(1));
 
-                if ((fromTdt - tdtsec) >= minLookbackSeconds) {
-                    break;
+                final String[] tripletFields = parseRecord(record, NUM_FIELDS_IN_TRIPLET);
+                final String tdtStr = tripletFields[TRIPLET_TDTG_FIELD_INDEX].substring(1);
+                final double tdtSec = TimeConvert.tdtCalStrToTdt(tdtStr);
+
+                if (smoothingRecordTdtStringsToIgnore.contains(tdtStr)) {
+                    logger.debug(String.format("getPriorRec: skipping record at TDT %s due to it being a smoothing record", tdtStr));
+                    continue;
                 }
-            }
 
+                if ((fromTdt - tdtSec) < minLookbackSeconds) {
+                    logger.debug(String.format("getPriorRec: skipping record at TDT %s due to not meeting lookback minimum", tdtStr));
+                    continue;
+                }
+
+                return tripletFields;
+            }
         } catch (TimeConvertException e) {
             throw new TextProductException("Unable to convert TDT string to numeric TDT seconds.", e);
         }
 
-        return tripletFields;
+        throw new TextProductException("Look back time invalid for the specified SCLK kernel.");
     }
 
 
@@ -274,33 +289,32 @@ public class SclkKernel extends TextProduct {
      * @return the new SCLK kernel time correlation record
      * @throws TextProductException if the kernel record could not be assembled
      */
-    private String assembleNewTripletRecord() throws TextProductException {
+    private static String assembleNewTripletRecord(CorrelationTriplet triplet, String sourceTripletAsStringForFormatting) throws TextProductException {
 
         /* Use the last existing record in the SCLK kernel data as the template to create the new one.
            This assures consistency of format and spacing. */
-        String record          = sourceProductLines.get(endDataNum);
-        String[] tripletFields = parseRecord(record, numFieldsInRecord);
+        String[] tripletFields = parseRecord(sourceTripletAsStringForFormatting, NUM_FIELDS_IN_TRIPLET);
 
         /* New encoded SCLK value. */
         DecimalFormat encSclkFormat = new DecimalFormat("#.#");
         encSclkFormat.setRoundingMode(RoundingMode.HALF_UP);
-        String encSclkStr = encSclkFormat.format(encSclk);
+        String encSclkStr = encSclkFormat.format(triplet.encSclk);
 
         /* Format the encoded SCLK field such that the new triplet entry left-aligns with the previous entry. */
         String record0;
-        if (encSclkStr.length() > tripletFields[ENCSCLK].length()) {
-            String paddedEncSclk = StringUtils.leftPad(tripletFields[ENCSCLK],encSclkStr.length(), ' ');
-            record0 = record.replaceFirst(paddedEncSclk, encSclkStr);
+        if (encSclkStr.length() > tripletFields[TRIPLET_ENCSCLK_FIELD_INDEX].length()) {
+            String paddedEncSclk = StringUtils.leftPad(tripletFields[TRIPLET_ENCSCLK_FIELD_INDEX],encSclkStr.length(), ' ');
+            record0 = sourceTripletAsStringForFormatting.replaceFirst(paddedEncSclk, encSclkStr);
         } else {
-            record0 = record.replaceFirst(tripletFields[ENCSCLK], encSclkStr);
+            record0 = sourceTripletAsStringForFormatting.replaceFirst(tripletFields[TRIPLET_ENCSCLK_FIELD_INDEX], encSclkStr);
         }
 
         /* New TDT value in calendar string form. */
-        String record1 = record0.replaceFirst(tripletFields[TDTG], "@" + tdtStr);
+        String record1 = record0.replaceFirst(tripletFields[TRIPLET_TDTG_FIELD_INDEX], "@" + triplet.tdtStr);
 
         /* New clock change rate value. */
-        String chgRateStr = formatChgRateStr(clockChgRate);
-        String record2    = record1.replaceFirst(tripletFields[CLKCHGRATE], chgRateStr);
+        String chgRateStr = formatChgRateStr(triplet.clkChgRate);
+        String record2    = record1.replaceFirst(tripletFields[TRIPLET_CLKCHGRATE_FIELD_INDEX], chgRateStr);
 
         return record2;
     }
@@ -342,7 +356,7 @@ public class SclkKernel extends TextProduct {
         recstr = recstr.replace(")", "");
 
         String[] fields = recstr.trim().split("\\s+");
-        if (fields.length == (ENCSCLK+TDTG+CLKCHGRATE)) {
+        if (fields.length == (TRIPLET_ENCSCLK_FIELD_INDEX + TRIPLET_TDTG_FIELD_INDEX + TRIPLET_CLKCHGRATE_FIELD_INDEX)) {
             isdata = fields[1].startsWith("@") ||
                     (isNumVal(fields[0]) && isNumVal(fields[1]) && isNumVal(fields[2]));
         }
@@ -392,12 +406,16 @@ public class SclkKernel extends TextProduct {
             newSclkKernel.setName(ctx.config.getSclkKernelBasename() + ctx.config.getSclkKernelSeparator() + ctx.newSclkVersionString.get() + ".tsc");
             newSclkKernel.setNewTriplet(
                     ctx.correlation.target.get().getTargetSampleEncSclk(),
-                    TimeConvert.tdtToTdtStr(ctx.correlation.target.get().getTargetSampleTdtG()),
+                    TimeConvert.tdtToTdtCalStr(ctx.correlation.target.get().getTargetSampleTdtG()),
                     ctx.correlation.predicted_clock_change_rate.get()
             );
 
             if (ctx.correlation.interpolated_clock_change_rate.isSet()) {
                 newSclkKernel.setReplacementClockChgRate(ctx.correlation.interpolated_clock_change_rate.get());
+            }
+
+            if (ctx.correlation.smoothingTriplet.isSet()) {
+                newSclkKernel.setSmoothingTriplet(ctx.correlation.smoothingTriplet.get());
             }
 
             newSclkKernel.createFile();
@@ -412,5 +430,9 @@ public class SclkKernel extends TextProduct {
         } catch (TextProductException | TimeConvertException ex) {
             throw new MmtcException("Unable to write SCLK kernel", ex);
         }
+    }
+
+    private void setSmoothingTriplet(CorrelationTriplet smoothingTriplet) {
+        this.smoothingTriplet = Optional.of(smoothingTriplet);
     }
 }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkScetFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/SclkScetFile.java
@@ -19,6 +19,7 @@ import java.util.*;
  * <P>See <I>Generic SCLK versus SCET Correlation File, SIS (MGSS DOC-000574, Rev. E)</I> for a full
  * description of this product.
  */
+// todo think about how to protect or account for the interaction of leap seconds and smoothing records
 public class SclkScetFile extends TextProduct {
 
     /**
@@ -346,7 +347,7 @@ public class SclkScetFile extends TextProduct {
                 else {
                     tdtStr = fields[1];
                 }
-                scetUtc = TimeConvert.parseIsoDoyUtcStr(TimeConvert.tdtStrToUtc(tdtStr, SclkScet.getScetStrSecondsPrecision()));
+                scetUtc = TimeConvert.parseIsoDoyUtcStr(TimeConvert.tdtCalStrToUtc(tdtStr, SclkScet.getScetStrSecondsPrecision()));
                 logger.trace("SclkScetFile.List(): tdtStr = " + tdtStr + ", scetUtc = " + scetUtc);
 
                 /* Compute the Delta Universal TIme (DUT) offset of UTC from TDT. */

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
@@ -160,8 +160,8 @@ public class TimeHistoryFile extends AbstractTimeCorrelationTable {
         newThfRec.setValue(TimeHistoryFile.OWLT_SEC, String.format("%.6f", ctx.correlation.owlt_sec.get()));
 
         // Record the ground computed TDT, ET, and SCET (UTC) values. These are the ground time equivalents of the SCLK.
-        final String tdtGStr = TimeConvert.tdtToTdtStr(ctx.correlation.target.get().getTargetSampleTdtG());
-        final String equivalent_scet_utc_for_tdt_g_iso_doy = TimeConvert.tdtStrToUtc(tdtGStr, ctx.config.getTimeHistoryFileScetUtcPrecision());
+        final String tdtGStr = TimeConvert.tdtToTdtCalStr(ctx.correlation.target.get().getTargetSampleTdtG());
+        final String equivalent_scet_utc_for_tdt_g_iso_doy = TimeConvert.tdtCalStrToUtc(tdtGStr, ctx.config.getTimeHistoryFileScetUtcPrecision());
         {
             newThfRec.setValue(TimeHistoryFile.TDT_G, tdf.format(ctx.correlation.target.get().getTargetSampleTdtG()));
             newThfRec.setValue(TimeHistoryFile.TDT_G_STR, tdtGStr);
@@ -263,7 +263,7 @@ public class TimeHistoryFile extends AbstractTimeCorrelationTable {
         newThfRec.setValue(TimeHistoryFile.TDT_1,                     () -> String.valueOf(ctx.ancillary.gnc.tdt_1.get()));
         newThfRec.setValue(TimeHistoryFile.TDT_1_STRING,              () -> {
             try {
-                return TimeConvert.tdtToTdtStr(ctx.ancillary.gnc.tdt_1.get());
+                return TimeConvert.tdtToTdtCalStr(ctx.ancillary.gnc.tdt_1.get());
             } catch (TimeConvertException e) {
                 throw new RuntimeException(e);
             }
@@ -276,7 +276,7 @@ public class TimeHistoryFile extends AbstractTimeCorrelationTable {
         newThfRec.setValue(TimeHistoryFile.TDT_S,                     () -> String.format("%.6f", ctx.ancillary.gnc.tdt_s.get()));
         newThfRec.setValue(TimeHistoryFile.TDT_S_STR,                 () -> {
             try {
-                return TimeConvert.tdtToTdtStr(ctx.ancillary.gnc.tdt_s.get());
+                return TimeConvert.tdtToTdtCalStr(ctx.ancillary.gnc.tdt_s.get());
             } catch (TimeConvertException e) {
                 throw new RuntimeException(e);
             }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
@@ -195,10 +195,10 @@ public class TimeHistoryFile extends AbstractTimeCorrelationTable {
         }
 
         switch (ctx.correlation.actual_clock_change_rate_mode.get()) {
-            case COMPUTE_INTERPOLATED:
+            case COMPUTE_INTERPOLATE:
                 newThfRec.setValue(TimeHistoryFile.CLK_CHANGE_RATE_MODE, "I");
                 break;
-            case COMPUTE_PREDICTED:
+            case COMPUTE_PREDICT:
                 newThfRec.setValue(TimeHistoryFile.CLK_CHANGE_RATE_MODE, "P");
                 break;
             case ASSIGN:

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/UplinkCmdFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/UplinkCmdFile.java
@@ -61,7 +61,7 @@ public class UplinkCmdFile {
                     ctx.correlation.target.get().getTargetSample().getTkSclkCoarse(),
                     ctx.correlation.target.get().getTargetSampleEtG(),
                     ctx.correlation.target.get().getTargetSampleTdtG(),
-                    TimeConvert.tdtToTdtStr(ctx.correlation.target.get().getTargetSampleTdtG()),
+                    TimeConvert.tdtToTdtCalStr(ctx.correlation.target.get().getTargetSampleTdtG()),
                     ctx.correlation.predicted_clock_change_rate.get()
             );
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/util/TimeConvert.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/util/TimeConvert.java
@@ -13,7 +13,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.time.Year;
 
-import org.apache.commons.beanutils.converters.BigDecimalConverter;
 import org.apache.commons.lang3.StringUtils;
 
 import spice.basic.*;
@@ -26,7 +25,7 @@ import spice.basic.*;
  * JNISpice Java interface to their CSPICE library. Unless loaded already in
  * the calling application, the <code>loadSpiceLib()</code> function should be
  * called to load CSPICE and the necessary SPICE kernels before any
- * other functions in this class are called. It need be called only once.
+ * other functions in this class are called. It needs be called only once.
  *
  * <P>The NAIF SPICE documentation is extensive, available on-line, and provides
  * a full description of SPICE and its usage.
@@ -595,16 +594,16 @@ import spice.basic.*;
      *  dd-MMM-yyyy-hh:mm:ss.ssssss
      *  e.g., "19-DEC-2017-05:50:08.956750"
      *
-     * @param tdtstr  IN the TDT in calendar string form
+     * @param tdtCalStr  IN the TDT in calendar string form
      * @return TDT in numeric seconds of J2000 epoch form
      * @throws TimeConvertException when there is a SPICE error
      */
-    public static Double tdtStrToTdt(String tdtstr) throws TimeConvertException {
+    public static Double tdtCalStrToTdt(String tdtCalStr) throws TimeConvertException {
 
         Double tdt;
 
         try {
-            double et = CSPICE.str2et(tdtstr + " TDT");
+            double et = CSPICE.str2et(tdtCalStr + " TDT");
             tdt = etToTdt(et);
 
         } catch (SpiceErrorException e) {
@@ -626,7 +625,7 @@ import spice.basic.*;
      * @return TDT in calendar string form
      * @throws TimeConvertException when there is a SPICE error
      */
-    public static String tdtToTdtStr(Double tdt) throws TimeConvertException {
+    public static String tdtToTdtCalStr(Double tdt) throws TimeConvertException {
 
         String tdtStr;
 
@@ -651,18 +650,18 @@ import spice.basic.*;
     /**
      * Converts a TDT string to a UTC ISO day of year calendar string.
      *
-     * @param tdtStr     IN the TDT as a calendar string
-     * @param precision  IN the number of digits of fractional seconds
+     * @param tdtCalStr     IN the TDT as a calendar string
+     * @param precision          IN the number of digits of fractional seconds
      * @return the UTC string
      * @throws TimeConvertException if the TDT could not be converted to UTC
      */
-    public static String tdtStrToUtc(String tdtStr, Integer precision) throws TimeConvertException {
+    public static String tdtCalStrToUtc(String tdtCalStr, Integer precision) throws TimeConvertException {
 
         String utc;
 
         try {
 
-            double et  = CSPICE.str2et(tdtStr + " TDT");
+            double et  = CSPICE.str2et(tdtCalStr + " TDT");
             utc        = CSPICE.et2utc(et, "ISOD", precision);
 
         } catch (SpiceErrorException e) {

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/util/TimeConvert.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/util/TimeConvert.java
@@ -25,7 +25,7 @@ import spice.basic.*;
  * JNISpice Java interface to their CSPICE library. Unless loaded already in
  * the calling application, the <code>loadSpiceLib()</code> function should be
  * called to load CSPICE and the necessary SPICE kernels before any
- * other functions in this class are called. It needs be called only once.
+ * other functions in this class are called. It needs to be called only once.
  *
  * <P>The NAIF SPICE documentation is extensive, available on-line, and provides
  * a full description of SPICE and its usage.

--- a/mmtc-core/src/main/resources/TimeCorrelationConfigProperties.xsd
+++ b/mmtc-core/src/main/resources/TimeCorrelationConfigProperties.xsd
@@ -89,6 +89,8 @@
       <!-- Alarm thresholds -->
       <xs:enumeration value="compute.tdtS.threshold.errorMsecWarning"/>
 
+      <xs:enumeration value="compute.clkchgrate.mode"/>
+
       <xs:enumeration value="compute.additionalSmoothingCorrelationRecordInsertion.enabled"/>
       <xs:enumeration value="compute.additionalSmoothingCorrelationRecordInsertion.coarseSclkTickDuration"/>
 

--- a/mmtc-core/src/main/resources/TimeCorrelationConfigProperties.xsd
+++ b/mmtc-core/src/main/resources/TimeCorrelationConfigProperties.xsd
@@ -89,6 +89,9 @@
       <!-- Alarm thresholds -->
       <xs:enumeration value="compute.tdtS.threshold.errorMsecWarning"/>
 
+      <xs:enumeration value="compute.additionalSmoothingCorrelationRecordInsertion.enabled"/>
+      <xs:enumeration value="compute.additionalSmoothingCorrelationRecordInsertion.coarseSclkTickDuration"/>
+
       <!-- Contact Filter Settings: The enabled setting can be overriden at the command line. Drift threshold values
       are in milliseconds/day.  -->
       <xs:enumeration value="filter.contact.enabled"/>

--- a/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/TimeConvertTests.java
+++ b/mmtc-core/src/test/java/edu/jhuapl/sd/sig/mmtc/TimeConvertTests.java
@@ -1,6 +1,5 @@
 package edu.jhuapl.sd.sig.mmtc;
 
-import edu.jhuapl.sd.sig.mmtc.app.TimeCorrelationApp;
 import edu.jhuapl.sd.sig.mmtc.util.CdsTimeCode;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
@@ -352,7 +351,7 @@ public class TimeConvertTests {
         KernelDatabase.load("src/test/resources/nh_kernels/lsk/naif0012.tls");
 
         /* Function to test */
-        Double tdt = TimeConvert.tdtStrToTdt("19-DEC-2017-05:50:08.956750");
+        Double tdt = TimeConvert.tdtCalStrToTdt("19-DEC-2017-05:50:08.956750");
 
         DecimalFormat secfmt = new DecimalFormat("##.######");
         secfmt.setRoundingMode(RoundingMode.HALF_UP);
@@ -376,7 +375,7 @@ public class TimeConvertTests {
         KernelDatabase.load("src/test/resources/nh_kernels/lsk/naif0012.tls");
 
         /* Function to test */
-        String tdtstr = TimeConvert.tdtToTdtStr(new Double(566934608.95675));
+        String tdtstr = TimeConvert.tdtToTdtCalStr(new Double(566934608.95675));
 
         System.out.println("tdtToTdtStr_test1: TDT value          = " + tdtstr);
 

--- a/mmtc-core/src/test/resources/examples/TimeCorrelationConfigProperties-all.xml
+++ b/mmtc-core/src/test/resources/examples/TimeCorrelationConfigProperties-all.xml
@@ -54,6 +54,8 @@
     <entry key="spice.kernel.fk.path"></entry>
     <entry key="spice.kernel.pck.path"></entry>
 
+    <entry key="compute.clkchgrate.mode"></entry>
+
     <entry key="compute.tdtG.rate.predicted.lookBackDays"></entry>
     <entry key="compute.tdtG.rate.predicted.maxLookBackDays"></entry>
 

--- a/mmtc-core/src/test/resources/examples/TimeCorrelationConfigProperties-all.xml
+++ b/mmtc-core/src/test/resources/examples/TimeCorrelationConfigProperties-all.xml
@@ -57,6 +57,9 @@
     <entry key="compute.tdtG.rate.predicted.lookBackDays"></entry>
     <entry key="compute.tdtG.rate.predicted.maxLookBackDays"></entry>
 
+    <entry key="compute.additionalSmoothingCorrelationRecordInsertion.enabled"></entry>
+    <entry key="compute.additionalSmoothingCorrelationRecordInsertion.coarseSclkTickDuration"></entry>
+
     <entry key="compute.tdtS.threshold.errorMsecWarning"></entry>
 
     <entry key="filter.contact.deltaUpperThreshold"></entry>


### PR DESCRIPTION
Add a smoothing record insertion option to provide SCLK-SCET continuity

See the details in #7 for more background and justification for this change.

When this new optional behavior is enabled:
- MMTC will append the same new correlation record to each SCLK kernel and SCLK-SCET file that it would normally append with whatever clkchgrate mode is enabled
- MMTC will also add an additional correlation record before this last new record, which 'smooths' the SCLK-SCET relationship over a configurable period of time prior to the new actual correlation record and an instant during the prior correlation record's applicability timeframe
  - This new record is placed a certain number of coarse SCLK ticks earlier than the new final record and is given a clock rate by interpolating between its own SCLK & SCET and that of the new final record
- MMTC will not use the additional smoothed correlation records for the basis for clock change rate calculations, by recording and reading their TDT(G) values from a new column in the Run History File

This behavior may be desired by missions that wish to have both a) stability in their SCLK-SCET time conversions between successive versions of SCLK kernels/SCLK-SCET files, and b) assured continuity (lack of gaps or inversions) in the SCLK-SCET relationship.

This behavior can be controlled by:
- Configuration
  - Config key `compute.additionalSmoothingCorrelationRecordInsertion.enabled` (with values `true` or `false`)
  - Config key `compute.additionalSmoothingCorrelationRecordInsertion.coarseSclkTickDuration` (with an integer value representing the number of SCLK coarse ticks prior to the new correlation this record will be inserted)
- Overriding configuration with CLI arguments:
  - '-s' or '--with-smoothing-record 20' to enable this behavior (and e.g. set its duration to 20 coarse ticks)
  - `-x` or `--without-smoothing-record` to disable this behavior

This new optional behavior can be enabled in every clock change rate mode except interpolate (`--clkchgrate-compute i`), as they essentially accomplish the same objective in different manners and in conflicting implementations.  Continuity is also achieved when using `--clkchgrate-compute i`.

These changes also add a new config key `compute.clkchgrate.mode` to set the default clock change rate mode.