### PR TITLE
[gh-22] Reformat encoded sclk from scientific notation to integer in the Time History File

### DIFF
--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/model/TimeHistoryFile.java
@@ -7,6 +7,7 @@ import edu.jhuapl.sd.sig.mmtc.tlm.FrameSample;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvert;
 import edu.jhuapl.sd.sig.mmtc.util.TimeConvertException;
 
+import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.file.Path;
 import java.text.DecimalFormat;
@@ -236,13 +237,14 @@ public class TimeHistoryFile extends AbstractTimeCorrelationTable {
         {
             newThfRec.setValue(TimeHistoryFile.TARGET_FRAME_SCLK_COARSE, String.valueOf(ctx.correlation.target.get().getTargetSample().getTkSclkCoarse()));
             newThfRec.setValue(TimeHistoryFile.TARGET_FRAME_ENC_SCLK,
-                    String.valueOf(TimeConvert.sclkToEncSclk(
+                    BigDecimal.valueOf(
+                            TimeConvert.sclkToEncSclk(
                                     ctx.config.getNaifSpacecraftId(),
                                     sclkPartition,
                                     ctx.correlation.target.get().getTargetSample().getTkSclkCoarse(),
                                     0
                             )
-                    )
+                    ).toPlainString()
             );
         }
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/util/GenericCsv.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/util/GenericCsv.java
@@ -125,6 +125,14 @@ public class GenericCsv {
         }
     }
 
+    public void replaceValAt(String colName, int rowNum, String newVal) throws MmtcException {
+        try {
+            rows.get(rowNum).replace(colName, newVal);
+        } catch (Exception e) {
+            throw new MmtcException(String.format("Failed to replace the value at row %d, column %s. Check that the value exists.", rowNum, colName));
+        }
+    }
+
     public int getNumRows() {
         return rows.size();
     }
@@ -143,5 +151,9 @@ public class GenericCsv {
         for (Map<String, String> row : rows) {
             row.remove(colName);
         }
+    }
+
+    public String getValAt(int rowNum, String colName) {
+        return String.valueOf(rows.get(rowNum).get(colName));
     }
 }


### PR DESCRIPTION
Also adds associated migration logic to retroactively convert previous encoded SCLK entries to the new integer format. Manually tested successfully, but E2E tests in the private repo still in the works. 