### PR TITLE
Merge release/1.6.0 to main, and bump to 1.7.0-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 allprojects {
     group = "edu.jhuapl.sd.sig"
-    version = "1.6.0-SNAPSHOT"
+    version = "1.6.0"
 
     repositories {
         maven {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 allprojects {
     group = "edu.jhuapl.sd.sig"
-    version = "1.6.0"
+    version = "1.7.0-SNAPSHOT"
 
     repositories {
         maven {

--- a/docs/MMTC_Users_Guide.adoc
+++ b/docs/MMTC_Users_Guide.adoc
@@ -576,7 +576,7 @@ The code block above gives the MMTC start-up Bash script. If possible, missions 
 
 == Running MMTC
 
-MMTC is invoked by running the startup script described in <<Invoking MMTC>>.  MMTC can be operated by its command-line interface or its GUI.
+The MMTC CLI is invoked by running the startup script described in <<Invoking MMTC>>.  MMTC can also be operated via its GUI (see <<Web application & graphical user interface>>).
 
 === CLI Arguments and options
 

--- a/docs/MMTC_Users_Guide.adoc
+++ b/docs/MMTC_Users_Guide.adoc
@@ -435,7 +435,7 @@ After installing the RPM, perform the following steps as needed:
 
 After upgrading an MMTC installation, run `bin/mmtc migrate` in order to migrate output product structures forward to their new versions, where applicable.  A backup archive in ZIP format will be created, should the prior state of the files be needed.
 
-MMTC can then be invoked from the command line. Change the working directory to the MMTC installation directory (`/opt/local/mmtc` by default), and then run:
+MMTC can then be used as desired.  To create a new correlation from the command line, change the working directory to the MMTC installation directory (`/opt/local/mmtc` by default), and then run:
 
 [source, bash]
 ----
@@ -462,7 +462,9 @@ with the correct path to log4j2.properties.
 * The log folder can be located anywhere; simply modify the log4j2.properties file’s *property.basedir* property to specify the path to the folder.
 * There is no requirement for all output products to be written to the same output folder. Simply ensure that the various output path properties in TimeCorrelationConfigProperties.xml point to the desired output paths.
 
-MMTC can then be invoked from the command line. Change the working directory to where the archive file was extracted, and then run:
+After upgrading an MMTC installation, run `bin/mmtc migrate` in order to migrate output product structures forward to their new versions, where applicable.  A backup archive in ZIP format will be created, should the prior state of the files be needed.
+
+MMTC can then be used as desired.  To create a new correlation from the command line, change the working directory to the MMTC installation directory (`/opt/local/mmtc` by default), and then run:
 
 [source, bash]
 ----
@@ -506,7 +508,7 @@ In order to run MMTC after it has been built, set up the runtime environment:
 
 [.red]#Please note that MMTC cannot interpolate environment variables within  TimeCorrelationConfigProperties.xml.#
 
-Once the environment has been configured, MMTC can be invoked from the command line.  Change the working directory to `./build/mmtc-dist-tmp`, and run the following:
+Once the environment has been configured, MMTC can be used as desired.  To create a new correlation from the command line, change the working directory to the MMTC installation directory (`/opt/local/mmtc` by default), and then run:
 
 [source, bash]
 ----
@@ -574,11 +576,11 @@ The code block above gives the MMTC start-up Bash script. If possible, missions 
 
 == Running MMTC
 
-MMTC is invoked by running the startup script described in <<Invoking MMTC>>. There is no GUI; MMTC is operated by its command-line interface only.
+MMTC is invoked by running the startup script described in <<Invoking MMTC>>.  MMTC can be operated by its command-line interface or its GUI.
 
-=== Arguments and options
+=== CLI Arguments and options
 
-MMTC takes two required arguments, a start time and a stop time in Earth Received Time (ERT) for the data to query from its telemetry source. These are calendar string values in UTC and in ISO of the format:
+MMTC's default operation creates a new correlation.  It requires at least two arguments: a start time and a stop time in Earth Received Time (ERT) for the data to query from its telemetry source. These are calendar string values in UTC and in ISO of the format:
 
 _yyyy-mm-ddThh:mm:ss.nnn_
 
@@ -634,8 +636,8 @@ The above example queries all AMPCS sessions for 2 hours and 2 minutes of teleme
 
 *Note*: If you get an error message suggesting that SPICE kernels are missing, it could be due to not all required kernels having been provided, but it could also be due to the spacecraft ephemeris SPK kernel not covering the start and stop times provided to MMTC. If this is the case, MMTC cannot compute the essential one-way light travel time (OWLT) and will fail.
 
-.MMTC Command Line Options
-[[table4, Table 4: MMTC Command Line Options]]
+.MMTC Correlation Command Line Options
+[[table4, Table 4: MMTC Correlation Command Line Options]]
 [%autowidth]
 |===
 |Short Option |Long Option |Value(s) |Description
@@ -699,7 +701,7 @@ remain unappended. Otherwise runs MMTC normally according to other options and c
 |-h
 |--help
 |N/A
-|Prints out a short summary of the command line usage and these options. If this option is specified, the MMTC will not perform time correlation.
+|Prints out a short summary of the command line usage, including these options. If this option is specified, the MMTC will not perform time correlation.
 
 |-v
 |--version
@@ -2136,7 +2138,7 @@ This web application is currently intended for use by a single user at a time, t
 
 === Configuring the MMTC web application
 
-The MMTC web application reads the same TimeCorrelationConfigProperties.xml file as the rest of the MMTC codebase, though it includes a few additional keys:
+The MMTC web application reads the same TimeCorrelationConfigProperties.xml file as the rest of the MMTC codebase, though it uses a few additional keys:
 
 .MMTC Web Application Configuration Parameters
 [[table8, Table 8: Configuration Parameters]]
@@ -2663,6 +2665,9 @@ NOTE: In the MMTC code, this value is given as “ET” in order to match how it
 
 | GNC
 | Guidance, Navigation, and Control
+
+| GUI
+| Graphical User Interface
 
 | I&T
 | Integration and Test

--- a/docs/MMTC_Users_Guide.adoc
+++ b/docs/MMTC_Users_Guide.adoc
@@ -261,7 +261,7 @@ the /output/ directory of the demo installation.
 With the MMTC demo directory set as the working directory, MMTC can be invoked with +
 `bin/mmtc 2017-342T00:00:00 2017-342T23:59:59 -F` +
 or any other combination of valid command line arguments as documented in
-<<Arguments and options>>.
+<<CLI Arguments and Options>>.
 
 === Demo Output Products
 With the above invocation, MMTC should create five total files: An SCLK kernel
@@ -362,7 +362,7 @@ with a new interpolated one. This method has been shown to provide a slightly mo
 This value is also written to the Time History File. Since MMTC creates the SCLK/SCET file from
 the SCLK kernel, the SCLK/SCET file will contain the same interpolated values for all but the very last time correlation,
 but rounded to one less digit of precision. *This is the recommended method of computing the clock change rate and is the
-default if no alternate clock change rate mode is specified with command line arguments* (see <<Arguments and options>>.
+default if no alternate clock change rate mode is specified with command line arguments* (see <<CLI Arguments and Options>>.
 
 [.underline]#*Assign Clock Change Rate*# +
 MMTC allows the user to assign the value for the clock change rate that will be written to the SCLK kernel and SCLK/SCET
@@ -578,7 +578,7 @@ The code block above gives the MMTC start-up Bash script. If possible, missions 
 
 The MMTC CLI is invoked by running the startup script described in <<Invoking MMTC>>.  MMTC can also be operated via its GUI (see <<Web application & graphical user interface>>).
 
-=== CLI Arguments and options
+=== CLI Arguments and Options
 
 MMTC's default operation creates a new correlation.  It requires at least two arguments: a start time and a stop time in Earth Received Time (ERT) for the data to query from its telemetry source. These are calendar string values in UTC and in ISO of the format:
 

--- a/docs/MMTC_Users_Guide.adoc
+++ b/docs/MMTC_Users_Guide.adoc
@@ -1,8 +1,8 @@
 = Multi-Mission Time Correlation User's Guide
 :authors: Robert Seng <robert.seng@jhuapl.edu>, John Lage <john.lage@jhuapl.edu>
-:revdate: January 8, 2026
-:revnumber: 1.6.0
-:revremark: Rev G
+:revdate: October 22, 2026
+:revnumber: 1.7.0
+:revremark: Rev H
 :imagesdir: ./images/
 :toc: macro
 :toc-title:
@@ -94,6 +94,11 @@ Added information on new feature to choose sample set building strategy.
 |Jan 8, 2026
 |Multiple
 |Updates for enhancements to MMTC for 1.6.0, including the new UI.
+
+|Rev H for Rel 1.7.0.
+|Oct 22, 2026
+|Multiple
+|TBD
 |===
 
 

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/util/BuiltInOutputProductMigrationManager.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/products/util/BuiltInOutputProductMigrationManager.java
@@ -28,7 +28,8 @@ public class BuiltInOutputProductMigrationManager {
 
     private static final List<String> MIGRATEABLE_MMTC_VERSIONS = Arrays.asList(
             "1.5.1",
-            "1.6.0"
+            "1.6.0",
+            "1.7.0"
     );
 
     private final MmtcConfig config;
@@ -46,6 +47,7 @@ public class BuiltInOutputProductMigrationManager {
         this.migrations = new HashMap<>();
         this.migrations.put("1.5.1", () -> null);
         this.migrations.put("1.6.0", this::migrateToMmtc1_6_0);
+        this.migrations.put("1.7.0", this::migrateToMmtc1_7_0);
     }
 
     public String getVersionOfExistingProducts() throws MmtcException {
@@ -86,6 +88,7 @@ public class BuiltInOutputProductMigrationManager {
     }
 
     public void migrate() throws MmtcException, IOException {
+        logger.info("Beginning built-in output product migration.");
         String versionOfExistingProducts = getVersionOfExistingProducts();
 
         if (versionOfExistingProducts.equals(this.currentMmtcAndProductVersion)) {
@@ -112,6 +115,7 @@ public class BuiltInOutputProductMigrationManager {
 
         for (String v : versionsToMigrateTo) {
             try {
+                logger.info(String.format("Migrating built-in products to %s", v));
                 migrations.get(v).call();
             } catch (Exception e) {
                 // give advice on restoring from backup
@@ -209,6 +213,26 @@ public class BuiltInOutputProductMigrationManager {
         rhf.updateLastRowWithColVal("Built-In Output Product Version", "1.6.0");
         rhf.write();
         logger.info(USER_NOTICE, mmtc160MigrationLogPrefix + "migrated Run History File at " + config.getRunHistoryFilePath());
+
+        return null;
+    }
+
+    /**
+     * Migrates MMTC output products from 1.6.0 to 1.7.0.
+     *
+     * @return null
+     * @throws MmtcException
+     */
+    private Void migrateToMmtc1_7_0() throws MmtcException {
+        final String mmtc170MigrationLogPrefix = "MMTC 1.7.0 migration: ";
+
+        // No actual migrations yet
+
+        // Update the RHF's latest entry with the RHF to indicate a migration has occurred to this version
+        final GenericCsv rhf = new GenericCsv(config.getRunHistoryFilePath());
+        rhf.updateLastRowWithColVal("Built-In Output Product Version", "1.7.0");
+        rhf.write();
+        logger.info(USER_NOTICE, mmtc170MigrationLogPrefix + "migrated Run History File at " + config.getRunHistoryFilePath());
 
         return null;
     }

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/util/TimeConvert.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/util/TimeConvert.java
@@ -1263,7 +1263,7 @@ public class TimeConvert {
                 config.getTkSclkFineTickModulus()
         );
 
-        // expected SCET is the value TDT(G) value as converted using the SCLK kernel
+        // estimated SCET is the FrameSample's TDT(G) value as converted using the SCLK kernel
         double estimatedEtUsingSclkKernel  = CSPICE.sct2e(config.getNaifSpacecraftId(), tcTarget.getTargetSampleEncSclk());
         double estimatedTdtUsingSclkkernel = CSPICE.unitim(estimatedEtUsingSclkKernel, "ET", "TDT");
         final OffsetDateTime estimatedScet = tdtToUtc(estimatedTdtUsingSclkkernel, 9);
@@ -1271,7 +1271,7 @@ public class TimeConvert {
         // actual SCET is the actual TDT_G, in SCET terms, that was read on the ground
         final OffsetDateTime actualScet = tdtToUtc(tcTarget.getTargetSampleTdtG(), 9);
 
-        // for our estimated - actual calculation, we want the error term to be negative if the estimated value is larger (later) than the actual value, which would correspond to a 'negative' result from ChronoUnit.between, so invert the sign
+        // for our estimated - actual calculation, we want the error term to be positive if the estimated value is larger (later) than the actual value, which would correspond to a 'negative' result from ChronoUnit.between, so invert the sign
         return new FrameSampleMetrics(
                 tcTarget.getTargetSampleTdtG(),
                 actualScet,


### PR DESCRIPTION
Merges `release/1.6.0` branch into `main` and bumps to version 1.7.0-SNAPSHOT.  In doing so, the following changes were made:
- Updates version strings where applicable
- Adds version and next release info to User Guide
- Adds an output product migration step to update to 1.7.0