### PR TITLE
[#96, #97] Improve rollback to handle filenames with non-version-related digits; add AMPCS session filtering feature

### DIFF
--- a/docs/MMTC_Users_Guide.adoc
+++ b/docs/MMTC_Users_Guide.adoc
@@ -1526,15 +1526,25 @@ The parameters in the table below are only applicable to missions using AMPCS wh
 |STR
 |The name of the CSV field output by chill_get_frames that contains the target frame ground station identifier. Applicable only it telemetry.source.name is set to AmpcsTlmWithFrames.
 
+|telemetry.source.plugin.ampcs.frame.vcidFieldName
+|CONDITIONAL
+|STR
+|The name of the CSV field output by chill_get_frames that contains the target frame Virtual Channel ID (VCID). Applicable only if telemetry.source.name is set to AmpcsTlmWithFrames.
+
 |telemetry.source.plugin.ampcs.frame.vcfcFieldName
 |CONDITIONAL
 |STR
 |The name of the CSV field output by chill_get_frames that contains the target frame Virtual Channel Frame Count (VCFC). Applicable only if telemetry.source.name is set to AmpcsTlmWithFrames.
 
-|telemetry.source.plugin.ampcs.frame.vcidFieldName
+|telemetry.source.plugin.ampcs.session.sessionIdFieldName
 |CONDITIONAL
 |STR
-|The name of the CSV field output by chill_get_frames that contains the target frame Virtual Channel ID (VCID). Applicable only if telemetry.source.name is set to AmpcsTlmWithFrames.
+|The name of the CSV field output by chill_get_sessions that contains the Session ID string (an integer.)  Applicable only if telemetry.source.plugin.ampcs.sessionFilter is set.
+
+|telemetry.source.plugin.ampcs.sessionFilter
+|OPTIONAL
+|STR
+|If set to a nonempty value, MMTC's AMPCS telemetry sources will limit telemetry retrieval through the chill* interfaces to a subset of all sessions.  This key's value should be set to the chill_get_sessions* CLI query options that will return the subset of sessions to use for all telemetry retrieval via chill_get_packets, chill_get_frames, and/or chill_get_chanvals.
 
 |telemetry.source.plugin.ampcs.frame.maxTkpacketFrameSeparation
 |CONDITIONAL

--- a/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/rollback/TimeCorrelationRollback.java
+++ b/mmtc-core/src/main/java/edu/jhuapl/sd/sig/mmtc/rollback/TimeCorrelationRollback.java
@@ -23,6 +23,8 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -422,9 +424,23 @@ public class TimeCorrelationRollback {
             }
 
             for (File foundFile : foundFiles){
-                int fileId = Integer.parseInt(foundFile.getName().replaceAll("^\\D*(\\d+).*$", "$1"));
-                if ((! newLatestProductVersion.isPresent() || fileId > Integer.parseInt(newLatestProductVersion.get()))) {
-                    logger.info(String.format("Removing %s because its version %d is earlier than new latest version %s", foundFile, fileId, newLatestProductVersion));
+                // find the last contiguous group of digits in the filename, and assume that is the version string
+                // todo create a stronger model of product output filenames, including prefixes, version strings, and suffixes, and replace this with that
+
+                Pattern p = Pattern.compile("(\\d+)");
+                Matcher m = p.matcher(foundFile.getName());
+                String fileVersionStr = null;
+                while (m.find()) {
+                    fileVersionStr = m.group(1);
+                }
+
+                if (fileVersionStr == null) {
+                    throw new IllegalStateException("Unable to find version integer in filename: " + foundFile.getName());
+                }
+
+                int fileVersion = Integer.parseInt(fileVersionStr);
+                if ((! newLatestProductVersion.isPresent() || fileVersion > Integer.parseInt(newLatestProductVersion.get()))) {
+                    logger.info(String.format("Removing %s because its version %d is higher than new latest version %s", foundFile, fileVersion, newLatestProductVersion));
                     filesToDelete.add(foundFile);
                 }
             }

--- a/mmtc-core/src/test/resources/examples/TimeCorrelationConfigProperties-all.xml
+++ b/mmtc-core/src/test/resources/examples/TimeCorrelationConfigProperties-all.xml
@@ -116,6 +116,7 @@
     <!-- AMPCS configuration keys -->
     <entry key="telemetry.source.plugin.ampcs.chillTimeoutSec"></entry>
     <entry key="telemetry.source.plugin.ampcs.additionalChillCliParms"></entry>
+    <entry key="telemetry.source.plugin.ampcs.sessionFilter"></entry>
     <entry key="telemetry.source.plugin.ampcs.tkPacket.tkPacketHeaderFineSclkModulus"></entry>
 
     <!-- timekeeping packet configuration -->
@@ -130,6 +131,8 @@
     <entry key="telemetry.source.plugin.ampcs.tkpacket.vcfcFieldName"></entry>
     <entry key="telemetry.source.plugin.ampcs.tkpacket.dssIdFieldName"></entry>
     <entry key="telemetry.source.plugin.ampcs.tkpacket.pktLengthFieldName"></entry>
+
+    <entry key="telemetry.source.plugin.ampcs.session.sessionIdFieldName"></entry>
 
     <!-- channel value configuration -->
     <entry key="telemetry.source.plugin.ampcs.channel.channelIdFieldName"></entry>

--- a/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTelemetrySource.java
+++ b/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTelemetrySource.java
@@ -55,9 +55,9 @@ public abstract class AmpcsTelemetrySource implements TelemetrySource {
     protected String chillGdsPath;
 
     /**
-     * The AMPCS session ID.
+     * AMPCS session IDs.
      */
-    protected String sessionId = null;
+    protected List<String> cliSessionIds = new ArrayList<>();
 
     /**
      * Any additional AMPCS arguments.
@@ -74,7 +74,6 @@ public abstract class AmpcsTelemetrySource implements TelemetrySource {
 
     // ExecutorService to manage a thread pool to consume subprocess pipes.
     private ExecutorService executorService;
-
 
     public AmpcsTelemetrySource() {
     }
@@ -96,7 +95,7 @@ public abstract class AmpcsTelemetrySource implements TelemetrySource {
                 "K",
                 "ampcs-session-id",
                 true,
-                "Specifies the session ID when using an AMPCS telemetry source."
+                "Specifies the session ID(s) when using an AMPCS telemetry source. Multiple comma-separated values may be provided."
         );
 
         Option connectionParmsOpt = new Option(
@@ -119,10 +118,19 @@ public abstract class AmpcsTelemetrySource implements TelemetrySource {
     }
 
     @Override
-    public void applyOption(String name, String value) throws MmtcException {
+    public void applyOption(String name, String value) {
         switch(name) {
             case AMPCS_SESSION_ID_OPT: {
-                setSessionId(value);
+                List<String> sessionIds = Arrays.stream(value.split(","))
+                        .map(String::trim)
+                        .filter(s -> ! s.isEmpty())
+                        .collect(Collectors.toList());
+
+                if (sessionIds.isEmpty()) {
+                    throw new IllegalArgumentException("Empty or invalid session IDs provided");
+                }
+
+                this.cliSessionIds = sessionIds;
                 break;
             }
             case ADDITIONAL_AMPCS_CLI_ARGS_OPT: {
@@ -182,11 +190,6 @@ public abstract class AmpcsTelemetrySource implements TelemetrySource {
 
             if (stdout.contains("AMPCS")) {
                 logger.debug("Verified that MMTC is able to call AMPCS chill_get_packets.");
-                if (this.sessionId != null) {
-                    logger.debug(String.format("Calls to AMPCS will use session ID %s.", this.sessionId));
-                } else {
-                    logger.debug("Calls to AMPCS will not use a session ID.");
-                }
                 connectedToAmpcs = true;
             }
 
@@ -202,16 +205,6 @@ public abstract class AmpcsTelemetrySource implements TelemetrySource {
         logger.info("Connected.");
     }
 
-    private void setSessionId(String sessionId) throws MmtcException {
-        // Allow null; otherwise, verify that the session ID is a positive integer.
-        if (sessionId == null || (sessionId.matches("\\d+") && !sessionId.matches("0+"))) {
-            this.sessionId = sessionId;
-        } else {
-            throw new MmtcException(String.format(
-                    "Invalid session ID %d.  Session ID is optional, but if specified, it must be a positive integer.", sessionId
-            ));
-        }
-    }
 
     private void setChillTimeout(int timeoutSec) throws MmtcException {
         if (timeoutSec > 0) {
@@ -287,13 +280,10 @@ public abstract class AmpcsTelemetrySource implements TelemetrySource {
             String endTime = endTimeAsOffsetDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME).split("\\+")[0];
             endTime = endTime.replace("Z", "");
 
-            String queryCmd = chillGdsPath + "/bin/chill_get_chanvals --showColumns ";
+            String queryCmd = chillGdsPath + "/bin/chill_get_chanvals --showColumns";
+            queryCmd += getChillSessionIdOpt();
 
-            if (sessionId != null) {
-                queryCmd += String.format("-K %s ", sessionId);
-            }
-
-            queryCmd += String.format("--timeType SCET --beginTime %s --endTime %s ", beginTime, endTime);
+            queryCmd += String.format(" --timeType SCET --beginTime %s --endTime %s ", beginTime, endTime);
 
             final Optional<ChanValReadConfig> gncSclkChannelConfig     = ampcsConfig.getGncChanValReadConfig("gncsclk", true);
             final Optional<ChanValReadConfig> tdtSChannelConfig        = ampcsConfig.getGncChanValReadConfig("tdts", true);
@@ -380,62 +370,106 @@ public abstract class AmpcsTelemetrySource implements TelemetrySource {
 
         logger.debug("Getting the temperature for oscillator " + oscillatorId + ".");
 
-        Optional<ChanValReadConfig> oscTempChanValReadConfig = ampcsConfig.getOscTempChanValReadConfig(oscillatorId);
-
-        if (! oscTempChanValReadConfig.isPresent()) {
-            logger.info("Skipping retrieval of oscillator temperature, as channel value information was not provided in configuration.");
-            return Double.NaN;
-        }
-
-        final String tkOscTempChannelId = oscTempChanValReadConfig.get().channelId;
-        final String tkOscTempReadField = oscTempChanValReadConfig.get().readField;
-
-        // Create a bounding time +/- seconds to query the channels at.
-        OffsetDateTime time_minus = scet.minusSeconds(config.getTkOscTempWindowSec());
-        String beginTime = time_minus.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME).split("\\+")[0];
-        beginTime = beginTime.replace("Z", "");
-
-        OffsetDateTime time_plus = scet.plusSeconds(config.getTkOscTempWindowSec());
-        String endTime = time_plus.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME).split("\\+")[0];
-        endTime = endTime.replace("Z", "");
-
-        logger.debug("Obtaining temperature for oscillator " + oscillatorId + " (from channel ID "
-                + tkOscTempChannelId + ").");
-
-        String queryCmd = chillGdsPath+"/bin/chill_get_chanvals --showColumns";
-        if (sessionId != null) {
-            queryCmd += " -K " + sessionId;
-        }
-
-        queryCmd += " --timeType SCET --channelIds " + tkOscTempChannelId +
-                " --beginTime "  + beginTime +
-                " --endTime "    + endTime;
-
-        if (connectionParms != null) {
-            queryCmd += " " + connectionParms;
-        }
-
-        // Get the channels associated with the packet.
-        CSVParser channelValueOutputs;
         try {
+            Optional<ChanValReadConfig> oscTempChanValReadConfig = ampcsConfig.getOscTempChanValReadConfig(oscillatorId);
+
+            if (! oscTempChanValReadConfig.isPresent()) {
+                logger.info("Skipping retrieval of oscillator temperature, as channel value information was not provided in configuration.");
+                return Double.NaN;
+            }
+
+            final String tkOscTempChannelId = oscTempChanValReadConfig.get().channelId;
+            final String tkOscTempReadField = oscTempChanValReadConfig.get().readField;
+
+            // Create a bounding time +/- seconds to query the channels at.
+            OffsetDateTime time_minus = scet.minusSeconds(config.getTkOscTempWindowSec());
+            String beginTime = time_minus.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME).split("\\+")[0];
+            beginTime = beginTime.replace("Z", "");
+
+            OffsetDateTime time_plus = scet.plusSeconds(config.getTkOscTempWindowSec());
+            String endTime = time_plus.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME).split("\\+")[0];
+            endTime = endTime.replace("Z", "");
+
+            logger.debug("Obtaining temperature for oscillator " + oscillatorId + " (from channel ID "
+                    + tkOscTempChannelId + ").");
+
+            String queryCmd = chillGdsPath+"/bin/chill_get_chanvals --showColumns";
+            queryCmd += getChillSessionIdOpt();
+
+            queryCmd += " --timeType SCET --channelIds " + tkOscTempChannelId +
+                    " --beginTime "  + beginTime +
+                    " --endTime "    + endTime;
+
+            if (connectionParms != null) {
+                queryCmd += " " + connectionParms;
+            }
+
+            // Get the channels associated with the packet.
+            CSVParser channelValueOutputs;
+
             channelValueOutputs = runSubprocessCsv(queryCmd);
+
+            SingleChanValReader channelValueReader = new SingleChanValReader(ampcsConfig, new ChanValReadConfig(tkOscTempChannelId, tkOscTempReadField), scet);
+
+            for (CSVRecord channelValueRow : channelValueOutputs) {
+                channelValueReader.read(channelValueRow);
+            }
+
+            double oscillatorTemperature = channelValueReader.getValueClosestToTargetScet();
+
+            if (Double.isNaN(oscillatorTemperature)) {
+                logger.warn("No oscillator temperature data found in the sampling interval (channel ID " + tkOscTempChannelId + ").");
+            }
+
+            return oscillatorTemperature;
         } catch (IOException e) {
             throw new MmtcException("Unable to retrieve oscillator temperature", e);
         }
+    }
 
-        SingleChanValReader channelValueReader = new SingleChanValReader(ampcsConfig, new ChanValReadConfig(tkOscTempChannelId, tkOscTempReadField), scet);
+    protected String getChillSessionIdOpt() throws IOException {
+        // if session IDs are passed on the CLI, use those
+        if (! cliSessionIds.isEmpty()) {
+            if (ampcsConfig.getSessionFilter().isPresent()) {
+                logger.info("Using CLI-provided session ID instead of configured session query filter");
+            }
 
-        for (CSVRecord channelValueRow : channelValueOutputs) {
-            channelValueReader.read(channelValueRow);
+            return " -K " + String.join(",", cliSessionIds);
         }
 
-        double oscillatorTemperature = channelValueReader.getValueClosestToTargetScet();
-
-        if (Double.isNaN(oscillatorTemperature)) {
-            logger.warn("No oscillator temperature data found in the sampling interval (channel ID " + tkOscTempChannelId + ").");
+        // else, if a filter is configured, execute the filter to find which sessions to search
+        if (ampcsConfig.getSessionFilter().isPresent()) {
+            return " -K " + String.join(",", findSessionIdsMatchingFilter());
         }
 
-        return oscillatorTemperature;
+        // else, do not filter on session ID
+        return "";
+    }
+
+    private List<String> findSessionIdsMatchingFilter() throws IOException {
+        String chillGetSessionsCliOpts = ampcsConfig.getSessionFilter().orElseThrow(() -> new IllegalStateException("This method may only be called if the session filter configuration is set"));
+
+        String cmd = chillGdsPath + "/bin/chill_get_sessions -m";
+        cmd += " " + chillGetSessionsCliOpts;
+
+        if (connectionParms != null) {
+            cmd += " " + connectionParms;
+        }
+
+        CSVParser matchingSessionMetadata = runSubprocessCsv(cmd);
+
+        List<String> matchingSessionIds = matchingSessionMetadata.stream()
+                .map(rec -> rec.get(ampcsConfig.getSessionIdFieldName()))
+                .sorted()
+                .collect(Collectors.toList());
+
+        if (matchingSessionIds.isEmpty()) {
+            throw new IOException("No sessions matched the criteria specified by the provided chill_get_sessions CLI options: " + chillGetSessionsCliOpts);
+        }
+
+        logger.debug("Session IDs matching filter: " + String.join(",", matchingSessionIds));
+
+        return matchingSessionIds;
     }
 
     /**
@@ -582,10 +616,6 @@ public abstract class AmpcsTelemetrySource implements TelemetrySource {
      */
     public boolean isConnectedToAmpcs() { return this.connectedToAmpcs; }
 
-    /**
-     * @return the current AMPCS session ID
-     */
-    public String getSessionId() { return this.sessionId; }
 
     /**
      * Obtains the current active oscillator from configration parameters.

--- a/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTelemetrySourceConfig.java
+++ b/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTelemetrySourceConfig.java
@@ -1,7 +1,6 @@
 package edu.jhuapl.sd.sig.mmtc.tlmplugin.ampcs;
 
 import edu.jhuapl.sd.sig.mmtc.cfg.MmtcConfigWithTlmSource;
-import edu.jhuapl.sd.sig.mmtc.tlm.TelemetrySource;
 import edu.jhuapl.sd.sig.mmtc.tlmplugin.ampcs.chanvals.ChanValReadConfig;
 
 import java.nio.file.Path;
@@ -219,6 +218,20 @@ public class AmpcsTelemetrySourceConfig {
     }
 
     /**
+     * The name of the field in the CSV metadata output from a chill_get_sessions command that contains the
+     * Session ID that uniquely identifies a session.
+     *
+     * @return the field name of the session ID
+     */
+    public String getSessionIdFieldName() {
+        if (! timeCorrelationAppConfig.containsNonEmptyKey("telemetry.source.plugin.ampcs.session.sessionIdFieldName")) {
+            throw new IllegalStateException("Please specify telemetry.source.plugin.ampcs.session.sessionIdFieldName (likely as the value 'sessionId')");
+        }
+
+        return timeCorrelationAppConfig.getString("telemetry.source.plugin.ampcs.session.sessionIdFieldName");
+    }
+
+    /**
      * Only applicable when using the AMPCS_CHILL_WITH_FRAMES telemetry source. When searching for
      * the target frame corresponding to a TK packet, search for frames whose ERT is at most this
      * many seconds earlier than the TK packet ERT.
@@ -227,6 +240,19 @@ public class AmpcsTelemetrySourceConfig {
      */
     public int getMaxTkpacketFrameSeparation() {
         return timeCorrelationAppConfig.getInt("telemetry.source.plugin.ampcs.frame.maxTkpacketFrameSeparation");
+    }
+
+    /**
+     * These are CLI arguments to append to chill_get_sessions to query for data within
+     *
+     * @return
+     */
+    public Optional<String> getSessionFilter() {
+        if (timeCorrelationAppConfig.containsNonEmptyKey("telemetry.source.plugin.ampcs.sessionFilter")) {
+            return Optional.of(timeCorrelationAppConfig.getString("telemetry.source.plugin.ampcs.sessionFilter"));
+        }
+
+        return Optional.empty();
     }
 
     /**

--- a/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTlmArchive.java
+++ b/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTlmArchive.java
@@ -111,9 +111,7 @@ public class AmpcsTlmArchive extends AmpcsTelemetrySource {
             // Run chill_get_* to query for all of the time correlation packets that are within the selected contact interval.
             // Query by APID and ERT.
             String cmd = chillGdsPath+"/bin/chill_get_packets -m";
-            if (sessionId != null) {
-                cmd += " -K " + sessionId;
-            }
+            cmd += getChillSessionIdOpt();
             cmd += " --packetApid " + TKPKTAPID + " --timeType ERT " +
                     "--beginTime " + beginTime + " --endTime " + endTime + " --report --filename " + packetOutputFilename;
             if (connectionParms != null) {

--- a/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTlmWithFrames.java
+++ b/mmtc-plugin-ampcs/src/main/java/edu/jhuapl/sd/sig/mmtc/tlmplugin/ampcs/AmpcsTlmWithFrames.java
@@ -135,9 +135,7 @@ public class AmpcsTlmWithFrames extends AmpcsTelemetrySource {
             // Run chill_get_packets to query for all of the time correlation packets that are within the selected
             // contact interval. Query by APID and ERT.
             String cmd = chillGdsPath+"/bin/chill_get_packets -m";
-            if (sessionId != null) {
-                cmd += " -K " + sessionId;
-            }
+            cmd += getChillSessionIdOpt();
             cmd += " --packetApid " + TKPKTAPID + " --timeType ERT " +
                     "--beginTime " + beginTime + " --endTime " + endTime + " --report --filename " + packetOutputFilename;
             if (connectionParms != null) {
@@ -183,7 +181,7 @@ public class AmpcsTlmWithFrames extends AmpcsTelemetrySource {
             }
 
             // do preliminary parsing to fill out batchQuery
-            final ChillGetFramesBatchQuery batchQuery = new ChillGetFramesBatchQuery(ampcsConfig, Optional.ofNullable(sessionId), Optional.ofNullable(connectionParms));
+            final ChillGetFramesBatchQuery batchQuery = new ChillGetFramesBatchQuery(ampcsConfig, getChillSessionIdOpt(), Optional.ofNullable(connectionParms));
 
             int csvRecordIdx = -1;
 
@@ -402,9 +400,7 @@ public class AmpcsTlmWithFrames extends AmpcsTelemetrySource {
             // Run chill_get_packets to query for all of the time correlation packets that are within the selected
             // contact interval. Query by APID and ERT.
             String cmd = chillGdsPath+"/bin/chill_get_packets -m";
-            if (sessionId != null) {
-                cmd += " -K " + sessionId;
-            }
+            cmd += getChillSessionIdOpt();
             cmd += " --packetApid " + TKPKTAPID + " --timeType ERT " +
                     "--beginTime " + beginTime + " --endTime " + endTime + " --report --filename " + packetOutputFilename;
             if (connectionParms != null) {
@@ -518,9 +514,7 @@ public class AmpcsTlmWithFrames extends AmpcsTelemetrySource {
                 // sample's ERT. (Also ask chill_get_frames to return the results sorted by ERT.)
 
                 cmd = chillGdsPath+"/bin/chill_get_frames -m";
-                if (sessionId != null) {
-                    cmd += " -K " + sessionId;
-                }
+                cmd += getChillSessionIdOpt();
                 cmd += " --timeType ERT " + "--beginTime " + frameBeginTime +
                         " --endTime " + ertStr + " --vcid " + vcid + " --vcfcs " + vcfc + " --orderBy ERT";
                 if (connectionParms != null) {
@@ -705,20 +699,20 @@ public class AmpcsTlmWithFrames extends AmpcsTelemetrySource {
 
         private final AmpcsTelemetrySourceConfig ampcsConfig;
         private final String chillGdsPath;
-        private final Optional<String> sessionId;
+        private final String sessionIdOpt;
         private final Optional<String> connectionParams;
 
         private final Map<Integer, RangeSet<OffsetDateTime>> queryRangesByVcid;
         private final Map<Integer, Set<Integer>> vcfcsByVcid;
 
-        public ChillGetFramesBatchQuery(AmpcsTelemetrySourceConfig config, Optional<String> sessionId, Optional<String> connectionParams) throws MmtcException {
+        public ChillGetFramesBatchQuery(AmpcsTelemetrySourceConfig config, String sessionIdOpt, Optional<String> connectionParams) throws MmtcException {
             this.chillGdsPath = Environment.getEnvironmentVariable("CHILL_GDS");
             if (this.chillGdsPath == null) {
                 throw new MmtcException("Environment variable $CHILL_GDS is not set.");
             }
 
             this.ampcsConfig = config;
-            this.sessionId = sessionId;
+            this.sessionIdOpt = sessionIdOpt;
             this.connectionParams = connectionParams;
 
             queryRangesByVcid = new HashMap<>();
@@ -752,9 +746,7 @@ public class AmpcsTlmWithFrames extends AmpcsTelemetrySource {
 
                 for (OffsetDateTimeRange range : rangesToRunOver) {
                     String cmd = chillGdsPath + "/bin/chill_get_frames -m";
-                    if (sessionId.isPresent()) {
-                        cmd += " -K " + sessionId.get();
-                    }
+                    cmd += sessionIdOpt;
                     cmd += " --timeType ERT " + "--beginTime " + TimeConvert.timeToIsoUtcString(range.getStart()) +
                             " --endTime " + TimeConvert.timeToIsoUtcString(range.getStop()) + " --vcid " + vcid + " --vcfcs " + String.join(",", vcfcsToQueryFor) + " --orderBy ERT";
                     if (connectionParams.isPresent()) {


### PR DESCRIPTION
- [#96] Fix error with handling rollback on filenames that include digits outside the version portion
  - Files whose names include integers (which do not belong to the version portion of the filename) posed an issue for the rollback code, which would incorrectly take the first contiguous group of digits as the products' version
  - These changes adjust the logic to instead take the last contiguous group of digits as the products' version.
- [#97] Improve AMPCS telemetry retrieval performance with new (optional) session filtering feature